### PR TITLE
Use deciders for exception handling

### DIFF
--- a/src/Akka.Streams.Kafka.Tests/Integration/PlainSinkIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/PlainSinkIntegrationTests.cs
@@ -112,7 +112,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
                 .RunWith(Producer.PlainSink(config), _materializer).Wait();
 
             // TODO: find a better way to test FailStage
-            act.ShouldThrow<AggregateException>().WithInnerException<Exception>();
+            act.ShouldThrow<AggregateException>().WithInnerException<KafkaException>();
         }
     }
 }

--- a/src/Akka.Streams.Kafka.Tests/Integration/PlainSourceIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/PlainSourceIntegrationTests.cs
@@ -151,7 +151,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
                 .WithGroupId(group1);
 
             var probe = CreateProbe(config, topic1, Subscriptions.Assignment(new TopicPartition(topic1, 0)));
-            probe.Request(1).ExpectError().Should().BeOfType<Exception>();
+            probe.Request(1).ExpectError().Should().BeOfType<KafkaException>();
         }
     }
 }

--- a/src/Akka.Streams.Kafka/Messages/MsgPackSerializer.cs
+++ b/src/Akka.Streams.Kafka/Messages/MsgPackSerializer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Confluent.Kafka.Serialization;
+using MessagePack.Resolvers;
 
 namespace Akka.Streams.Kafka.Messages
 {
@@ -7,12 +8,12 @@ namespace Akka.Streams.Kafka.Messages
     {
         public byte[] Serialize(T data)
         {
-            return MessagePack.MessagePackSerializer.Serialize(data);
+            return MessagePack.MessagePackSerializer.Serialize(data, ContractlessStandardResolver.Instance);
         }
 
         public T Deserialize(byte[] data)
         {
-            return MessagePack.MessagePackSerializer.Deserialize<T>(data);
+            return MessagePack.MessagePackSerializer.Deserialize<T>(data, ContractlessStandardResolver.Instance);
         }
     }
 }

--- a/src/Akka.Streams.Kafka/Stages/ConsumerStage.cs
+++ b/src/Akka.Streams.Kafka/Stages/ConsumerStage.cs
@@ -136,10 +136,10 @@ namespace Akka.Streams.Kafka.Stages
                     FailStage(exception);
                     break;
                 case Directive.Resume:
-                    // TODO: resume the stream
+                    // keep going
                     break;
                 case Directive.Restart:
-                    // TODO: restart the stream
+                    // keep going
                     break;
             }
         }
@@ -151,20 +151,7 @@ namespace Akka.Streams.Kafka.Stages
             if (!KafkaExtensions.IsBrokerErrorRetriable(error) && !KafkaExtensions.IsLocalErrorRetriable(error))
             {
                 var exception = new KafkaException(error);
-                switch (_decider(exception))
-                {
-                    case Directive.Stop:
-                        // Throw
-                        _completion.TrySetException(exception);
-                        FailStage(exception);
-                        break;
-                    case Directive.Resume:
-                        // TODO: resume the stream
-                        break;
-                    case Directive.Restart:
-                        // TODO: restart the stream
-                        break;
-                }
+                FailStage(exception);
             }
         }
 

--- a/src/Akka.Streams.Kafka/Stages/ConsumerStage.cs
+++ b/src/Akka.Streams.Kafka/Stages/ConsumerStage.cs
@@ -58,7 +58,7 @@ namespace Akka.Streams.Kafka.Stages
             _completion = completion;
 
             var supervisionStrategy = attributes.GetAttribute<ActorAttributes.SupervisionStrategy>(null);
-            _decider = supervisionStrategy != null ? supervisionStrategy.Decider : Deciders.StoppingDecider;
+            _decider = supervisionStrategy != null ? supervisionStrategy.Decider : Deciders.ResumingDecider;
 
             SetHandler(_out, onPull:() =>
             {

--- a/src/Akka.Streams.Kafka/Stages/ConsumerStage.cs
+++ b/src/Akka.Streams.Kafka/Stages/ConsumerStage.cs
@@ -5,31 +5,35 @@ using System.Threading.Tasks;
 using Akka.Streams.Kafka.Settings;
 using Akka.Streams.Stage;
 using Confluent.Kafka;
+using Akka.Streams.Supervision;
+using System.Runtime.Serialization;
 
 namespace Akka.Streams.Kafka.Stages
 {
     internal class KafkaSourceStage<K, V, Msg> : GraphStageWithMaterializedValue<SourceShape<Msg>, Task>
     {
-        private readonly ConsumerSettings<K, V> _settings;
-        private readonly ISubscription _subscription;
-
-        protected readonly Outlet<Msg> Out = new Outlet<Msg>("kafka.consumer.out");
+        public Outlet<Msg> Out { get; } = new Outlet<Msg>("kafka.consumer.out");
         public override SourceShape<Msg> Shape { get; }
+        public ConsumerSettings<K, V> Settings { get; }
+        public ISubscription Subscription { get; }
 
         public KafkaSourceStage(ConsumerSettings<K, V> settings, ISubscription subscription)
         {
-            _settings = settings;
-            _subscription = subscription;
+            Settings = settings;
+            Subscription = subscription;
             Shape = new SourceShape<Msg>(Out);
+            Settings = settings;
+            Subscription = subscription;
         }
 
         public override ILogicAndMaterializedValue<Task> CreateLogicAndMaterializedValue(Attributes inheritedAttributes)
         {
-            return new LogicAndMaterializedValue<Task>(new KafkaSourceStage<K, V>(_settings, _subscription, Shape), Task.CompletedTask);
+            var completion = new TaskCompletionSource<NotUsed>();
+            return new LogicAndMaterializedValue<Task>(new KafkaSourceStageLogic<K, V, Msg>(this, inheritedAttributes, completion), completion.Task);
         }
     }
 
-    internal class KafkaSourceStage<K, V> : TimerGraphStageLogic
+    internal class KafkaSourceStageLogic<K, V, Msg> : TimerGraphStageLogic
     {
         private readonly ConsumerSettings<K, V> _settings;
         private readonly ISubscription _subscription;
@@ -39,16 +43,22 @@ namespace Akka.Streams.Kafka.Stages
         private Action<Message<K, V>> _messagesReceived;
         private Action<IEnumerable<TopicPartition>> _partitionsAssigned;
         private Action<IEnumerable<TopicPartition>> _partitionsRevoked;
+        private readonly Decider _decider;
 
         private const string TimerKey = "PollTimer";
 
         private readonly Queue<Message<K, V>> _buffer = new Queue<Message<K, V>>();
+        private readonly TaskCompletionSource<NotUsed> _completion;
 
-        public KafkaSourceStage(ConsumerSettings<K, V> settings, ISubscription subscription, Shape shape) : base(shape)
+        public KafkaSourceStageLogic(KafkaSourceStage<K, V, Msg> stage, Attributes attributes, TaskCompletionSource<NotUsed> completion) : base(stage.Shape)
         {
-            _settings = settings;
-            _subscription = subscription;
-            _out = shape.Outlets.FirstOrDefault();
+            _settings = stage.Settings;
+            _subscription = stage.Subscription;
+            _out = stage.Out;
+            _completion = completion;
+
+            var supervisionStrategy = attributes.GetAttribute<ActorAttributes.SupervisionStrategy>(null);
+            _decider = supervisionStrategy != null ? supervisionStrategy.Decider : Deciders.StoppingDecider;
 
             SetHandler(_out, onPull:() =>
             {
@@ -102,7 +112,7 @@ namespace Akka.Streams.Kafka.Stages
             _consumer.OnPartitionsAssigned -= HandleOnPartitionsAssigned;
             _consumer.OnPartitionsRevoked -= HandleOnPartitionsRevoked;
 
-            Log.Debug($"Consumer stopped {_consumer.Name}");
+            Log.Debug($"Consumer stopped: {_consumer.Name}");
             _consumer.Dispose();
 
             base.PostStop();
@@ -117,6 +127,21 @@ namespace Akka.Streams.Kafka.Stages
         private void HandleConsumeError(object sender, Message message)
         {
             Log.Error(message.Error.Reason);
+            var exception = new SerializationException(message.Error.Reason);
+            switch (_decider(exception))
+            {
+                case Directive.Stop:
+                    // Throw
+                    _completion.TrySetException(exception);
+                    FailStage(exception);
+                    break;
+                case Directive.Resume:
+                    // TODO: resume the stream
+                    break;
+                case Directive.Restart:
+                    // TODO: restart the stream
+                    break;
+            }
         }
 
         private void HandleOnError(object sender, Error error)
@@ -125,7 +150,21 @@ namespace Akka.Streams.Kafka.Stages
 
             if (!KafkaExtensions.IsBrokerErrorRetriable(error) && !KafkaExtensions.IsLocalErrorRetriable(error))
             {
-                FailStage(new Exception(error.Reason));
+                var exception = new KafkaException(error);
+                switch (_decider(exception))
+                {
+                    case Directive.Stop:
+                        // Throw
+                        _completion.TrySetException(exception);
+                        FailStage(exception);
+                        break;
+                    case Directive.Resume:
+                        // TODO: resume the stream
+                        break;
+                    case Directive.Restart:
+                        // TODO: restart the stream
+                        break;
+                }
             }
         }
 

--- a/src/Akka.Streams.Kafka/Stages/ProducerStage.cs
+++ b/src/Akka.Streams.Kafka/Stages/ProducerStage.cs
@@ -5,24 +5,28 @@ using Akka.Streams.Kafka.Messages;
 using Akka.Streams.Kafka.Settings;
 using Akka.Streams.Stage;
 using Confluent.Kafka;
+using Akka.Streams.Supervision;
 
 namespace Akka.Streams.Kafka.Stages
 {
     internal sealed class ProducerStage<K, V> : GraphStage<FlowShape<ProduceRecord<K, V>, Task<Message<K, V>>>>
     {
-        private readonly ProducerSettings<K, V> _settings;
-        private Inlet<ProduceRecord<K, V>> In { get; } = new Inlet<ProduceRecord<K, V>>("kafka.producer.in");
-        private Outlet<Task<Message<K, V>>> Out { get; } = new Outlet<Task<Message<K, V>>>("kafka.producer.out");
+        public ProducerSettings<K, V> Settings { get; }
+        public Inlet<ProduceRecord<K, V>> In { get; } = new Inlet<ProduceRecord<K, V>>("kafka.producer.in");
+        public Outlet<Task<Message<K, V>>> Out { get; } = new Outlet<Task<Message<K, V>>>("kafka.producer.out");
 
         public ProducerStage(ProducerSettings<K, V> settings)
         {
-            _settings = settings;
+            Settings = settings;
             Shape = new FlowShape<ProduceRecord<K, V>, Task<Message<K, V>>>(In, Out);
         }
 
         public override FlowShape<ProduceRecord<K, V>, Task<Message<K, V>>> Shape { get; }
 
-        protected override GraphStageLogic CreateLogic(Attributes inheritedAttributes) => new ProducerStageLogic<K, V>(_settings, Shape);
+        protected override GraphStageLogic CreateLogic(Attributes inheritedAttributes)
+        {
+            return new ProducerStageLogic<K, V>(this, inheritedAttributes);
+        }
     }
 
     internal sealed class ProducerStageLogic<K, V> : GraphStageLogic
@@ -31,15 +35,19 @@ namespace Akka.Streams.Kafka.Stages
         private readonly TaskCompletionSource<NotUsed> _completionState = new TaskCompletionSource<NotUsed>();
         private Action<ProduceRecord<K, V>> _sendToProducer;
         private readonly ProducerSettings<K, V> _settings;
+        private readonly Decider _decider;
 
         private Inlet In { get; }
         private Outlet Out { get; }
 
-        public ProducerStageLogic(ProducerSettings<K, V> settings, Shape shape) : base(shape)
+        public ProducerStageLogic(ProducerStage<K, V> stage, Attributes attributes) : base(stage.Shape)
         {
-            In = shape.Inlets.FirstOrDefault();
-            Out = shape.Outlets.FirstOrDefault();
-            _settings = settings;
+            In = stage.In;
+            Out = stage.Out;
+            _settings = stage.Settings;
+
+            var supervisionStrategy = attributes.GetAttribute<ActorAttributes.SupervisionStrategy>(null);
+            _decider = supervisionStrategy != null ? supervisionStrategy.Decider : Deciders.StoppingDecider;
 
             SetHandler(In, 
                 onPush: () =>
@@ -97,7 +105,21 @@ namespace Akka.Streams.Kafka.Stages
 
             if (!KafkaExtensions.IsBrokerErrorRetriable(error) && !KafkaExtensions.IsLocalErrorRetriable(error))
             {
-                FailStage(new Exception(error.Reason));
+                var exception = new KafkaException(error);
+                switch (_decider(exception))
+                {
+                    case Directive.Stop:
+                        // Throw
+                        _completionState.TrySetException(exception);
+                        FailStage(exception);
+                        break;
+                    case Directive.Resume:
+                        // TODO: resume the stream
+                        break;
+                    case Directive.Restart:
+                        // TODO: restart the stream
+                        break;
+                }
             }
         }
 


### PR DESCRIPTION
Confluent.Kafka does not produce any exception, so I'm using only two my exceptions
- SerializationException - only in `OnConsumeError` event handler. `Producer` does not react on serialization error
- KafkaException - both in producer and consumer - for non-retriable errors