### PR TITLE
Update vmImage from 'vs2017-win2016' to 'windows-2019'

### DIFF
--- a/build-system/nightly-builds.yaml
+++ b/build-system/nightly-builds.yaml
@@ -2,7 +2,7 @@
 # See https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema for reference
 
 pool:
-  vmImage: vs2017-win2016
+  vmImage: windows-2019
   demands: Cmd
 
 trigger: none

--- a/build-system/windows-pr-validation.yaml
+++ b/build-system/windows-pr-validation.yaml
@@ -17,6 +17,6 @@ jobs:
 - template: azure-pipeline.template.yaml
   parameters:
     name: Windows
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
     scriptFileName: build.cmd
     scriptArgs: all


### PR DESCRIPTION
Update vmImage from 'vs2017-win2016' to 'windows-2019', the 'vs2017-win2016' image was deprecated, all CI/CD pipelines and nightly builds failed.