### PR TITLE
Update RELEASE_NOTES.md for v1.4.49 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 
 * [Upgraded to Akka.NET v1.4.49](https://github.com/akkadotnet/akka.net/releases/tag/1.4.49)
 * [Handle exceptions thrown from kafka message processing](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/324)
+* [Bump Confluent.Kafka from 1.9.3 to 2.0.2](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/325)
 
 #### 1.2.2 October 21 2022 ####
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+#### 1.4.49 January 27 2023 ####
+
+`Akka.Streams.Kafka` version will now be in lock-step with its Akka.NET package version.
+
+* [Upgraded to Akka.NET v1.4.49](https://github.com/akkadotnet/akka.net/releases/tag/1.4.49)
+* [Handle exceptions thrown from kafka message processing](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/324)
+
 #### 1.2.2 October 21 2022 ####
 
 * [Upgraded to Akka.NET v1.4.45](https://github.com/akkadotnet/akka.net/releases/tag/1.4.45)


### PR DESCRIPTION
#### 1.4.49 January 27 2023

`Akka.Streams.Kafka` version will now be in lock-step with its Akka.NET package version.

* [Upgraded to Akka.NET v1.4.49](https://github.com/akkadotnet/akka.net/releases/tag/1.4.49)
* [Handle exceptions thrown from kafka message processing](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/324)
* [Bump Confluent.Kafka from 1.9.3 to 2.0.2](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/325)