### PR TITLE
Update RELEASE_NOTES.md for 1.5.30 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,15 @@
+#### 1.5.30 October 3rd 2024 ####
+
+* [Upgraded to Akka.NET v1.5.30](https://github.com/akkadotnet/akka.net/releases/tag/1.5.30)
+* [Bump Confluent.Kafka to 2.4.0](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/402)
+
 #### 1.5.29 October 1st 2024 ####
+
+> [!NOTE]
+>
+> **Deprecated**
+>
+> Deprecated due to Akka.NET 1.5.29 deprecation. Please use 1.5.30 instead.
 
 * [Upgraded to Akka.NET v1.5.29](https://github.com/akkadotnet/akka.net/releases/tag/1.5.29)
 * [Bump Confluent.Kafka to 2.4.0](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/402)

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <!-- Nuget package versions -->
-    <AkkaVersion>1.5.29</AkkaVersion>
+    <AkkaVersion>1.5.30</AkkaVersion>
     <!-- Unit test Nuget package versions -->
     <NBenchVersion>1.2.2</NBenchVersion>
     <TestSdkVersion>17.4.1</TestSdkVersion>


### PR DESCRIPTION
## 1.5.30 October 3rd 2024

* [Upgraded to Akka.NET v1.5.30](https://github.com/akkadotnet/akka.net/releases/tag/1.5.30)
* [Bump Confluent.Kafka to 2.4.0](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/402)
