### PR TITLE
Refactor KafkaConsumerActor event handling from Mailbox to direct method call

### DIFF
--- a/src/Akka.Streams.Kafka.Tests/Integration/PlainPartitionedSourceIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/PlainPartitionedSourceIntegrationTests.cs
@@ -216,7 +216,7 @@ namespace Akka.Streams.Kafka.Tests.Integration
                 .TakeWhile(m => m < totalMessages, inclusive: true)
                 .RunWith(Sink.Last<int>(), Materializer);
 
-            var consumedMessages = await consumedMessagesTask.ShouldCompleteWithin(10.Seconds());
+            var consumedMessages = await consumedMessagesTask.ShouldCompleteWithin(60.Seconds());
             consumedMessages.Should().Be(totalMessages);
         }
 

--- a/src/Akka.Streams.Kafka.Tests/Integration/PlainSourceIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/PlainSourceIntegrationTests.cs
@@ -244,6 +244,13 @@ namespace Akka.Streams.Kafka.Tests.Integration
             }
 
             /// <inheritdoc />
+            public void OnLost(IImmutableSet<TopicPartitionOffset> revokedTopicPartitions,
+                IRestrictedConsumer consumer)
+            {
+                RevokeEventsCounter.IncrementAndGet();
+            }
+
+            /// <inheritdoc />
             public void OnAssign(IImmutableSet<TopicPartition> assignedTopicPartitions, IRestrictedConsumer consumer)
             {
                 AssignmentEventsCounter.IncrementAndGet();

--- a/src/Akka.Streams.Kafka.Tests/Integration/PlainSourceIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/PlainSourceIntegrationTests.cs
@@ -244,13 +244,6 @@ namespace Akka.Streams.Kafka.Tests.Integration
             }
 
             /// <inheritdoc />
-            public void OnLost(IImmutableSet<TopicPartitionOffset> revokedTopicPartitions,
-                IRestrictedConsumer consumer)
-            {
-                RevokeEventsCounter.IncrementAndGet();
-            }
-
-            /// <inheritdoc />
             public void OnAssign(IImmutableSet<TopicPartition> assignedTopicPartitions, IRestrictedConsumer consumer)
             {
                 AssignmentEventsCounter.IncrementAndGet();

--- a/src/Akka.Streams.Kafka/Helpers/PartitionEventHandler.cs
+++ b/src/Akka.Streams.Kafka/Helpers/PartitionEventHandler.cs
@@ -25,6 +25,11 @@ namespace Akka.Streams.Kafka.Helpers
         void OnRevoke(IImmutableSet<TopicPartitionOffset> revokedTopicPartitions, IRestrictedConsumer consumer);
 
         /// <summary>
+        /// Called when partitions are lost
+        /// </summary>
+        void OnLost(IImmutableSet<TopicPartitionOffset> revokedTopicPartitions, IRestrictedConsumer consumer);
+
+        /// <summary>
         /// Called when partitions are assigned
         /// </summary>
         void OnAssign(IImmutableSet<TopicPartition> assignedTopicPartitions, IRestrictedConsumer consumer);
@@ -51,6 +56,11 @@ namespace Akka.Streams.Kafka.Helpers
             }
 
             /// <inheritdoc />
+            public void OnLost(IImmutableSet<TopicPartitionOffset> revokedTopicPartitions, IRestrictedConsumer consumer)
+            {
+            }
+
+            /// <inheritdoc />
             public void OnAssign(IImmutableSet<TopicPartition> assignedTopicPartitions, IRestrictedConsumer consumer)
             {
             }
@@ -68,18 +78,27 @@ namespace Akka.Streams.Kafka.Helpers
         {
             private readonly Action<IImmutableSet<TopicPartition>> _partitionAssignedCallback;
             private readonly Action<IImmutableSet<TopicPartitionOffset>> _partitionRevokedCallback;
+            private readonly Action<IImmutableSet<TopicPartitionOffset>> _partitionLostCallback;
 
             public AsyncCallbacks(Action<IImmutableSet<TopicPartition>> partitionAssignedCallback,
-                Action<IImmutableSet<TopicPartitionOffset>> partitionRevokedCallback)
+                Action<IImmutableSet<TopicPartitionOffset>> partitionRevokedCallback, 
+                Action<IImmutableSet<TopicPartitionOffset>> partitionLostCallback)
             {
                 _partitionAssignedCallback = partitionAssignedCallback;
                 _partitionRevokedCallback = partitionRevokedCallback;
+                _partitionLostCallback = partitionLostCallback;
             }
 
             /// <inheritdoc />
             public void OnRevoke(IImmutableSet<TopicPartitionOffset> revokedTopicPartitions, IRestrictedConsumer consumer)
             {
                 _partitionRevokedCallback(revokedTopicPartitions);
+            }
+
+            /// <inheritdoc />
+            public void OnLost(IImmutableSet<TopicPartitionOffset> revokedTopicPartitions, IRestrictedConsumer consumer)
+            {
+                _partitionLostCallback(revokedTopicPartitions);
             }
 
             /// <inheritdoc />
@@ -113,6 +132,13 @@ namespace Akka.Streams.Kafka.Helpers
             {
                 _handler1?.OnRevoke(revokedTopicPartitions, consumer);
                 _handler2?.OnRevoke(revokedTopicPartitions, consumer);
+            }
+
+            /// <inheritdoc />
+            public void OnLost(IImmutableSet<TopicPartitionOffset> revokedTopicPartitions, IRestrictedConsumer consumer)
+            {
+                _handler1?.OnLost(revokedTopicPartitions, consumer);
+                _handler2?.OnLost(revokedTopicPartitions, consumer);
             }
 
             /// <inheritdoc />

--- a/src/Akka.Streams.Kafka/Helpers/PartitionEventHandler.cs
+++ b/src/Akka.Streams.Kafka/Helpers/PartitionEventHandler.cs
@@ -25,6 +25,11 @@ namespace Akka.Streams.Kafka.Helpers
         void OnRevoke(IImmutableSet<TopicPartitionOffset> revokedTopicPartitions, IRestrictedConsumer consumer);
 
         /// <summary>
+        /// Called when partitions are lost
+        /// </summary>
+        void OnLost(IImmutableSet<TopicPartitionOffset> revokedTopicPartitions, IRestrictedConsumer consumer);
+
+        /// <summary>
         /// Called when partitions are assigned
         /// </summary>
         void OnAssign(IImmutableSet<TopicPartition> assignedTopicPartitions, IRestrictedConsumer consumer);
@@ -50,6 +55,11 @@ namespace Akka.Streams.Kafka.Helpers
             {
             }
 
+            /// <inheritdoc />
+            public void OnLost(IImmutableSet<TopicPartitionOffset> revokedTopicPartitions, IRestrictedConsumer consumer)
+            {
+            }
+            
             /// <inheritdoc />
             public void OnAssign(IImmutableSet<TopicPartition> assignedTopicPartitions, IRestrictedConsumer consumer)
             {
@@ -83,6 +93,12 @@ namespace Akka.Streams.Kafka.Helpers
             }
 
             /// <inheritdoc />
+            public void OnLost(IImmutableSet<TopicPartitionOffset> revokedTopicPartitions, IRestrictedConsumer consumer)
+            {
+                OnRevoke(revokedTopicPartitions, consumer);
+            }
+            
+            /// <inheritdoc />
             public void OnAssign(IImmutableSet<TopicPartition> assignedTopicPartitions, IRestrictedConsumer consumer)
             {
                 _partitionAssignedCallback(assignedTopicPartitions);
@@ -115,6 +131,13 @@ namespace Akka.Streams.Kafka.Helpers
                 _handler2?.OnRevoke(revokedTopicPartitions, consumer);
             }
 
+            /// <inheritdoc />
+            public void OnLost(IImmutableSet<TopicPartitionOffset> revokedTopicPartitions, IRestrictedConsumer consumer)
+            {
+                _handler1?.OnLost(revokedTopicPartitions, consumer);
+                _handler2?.OnLost(revokedTopicPartitions, consumer);
+            }
+            
             /// <inheritdoc />
             public void OnAssign(IImmutableSet<TopicPartition> assignedTopicPartitions, IRestrictedConsumer consumer)
             {

--- a/src/Akka.Streams.Kafka/Helpers/PartitionEventHandler.cs
+++ b/src/Akka.Streams.Kafka/Helpers/PartitionEventHandler.cs
@@ -25,11 +25,6 @@ namespace Akka.Streams.Kafka.Helpers
         void OnRevoke(IImmutableSet<TopicPartitionOffset> revokedTopicPartitions, IRestrictedConsumer consumer);
 
         /// <summary>
-        /// Called when partitions are lost
-        /// </summary>
-        void OnLost(IImmutableSet<TopicPartitionOffset> revokedTopicPartitions, IRestrictedConsumer consumer);
-
-        /// <summary>
         /// Called when partitions are assigned
         /// </summary>
         void OnAssign(IImmutableSet<TopicPartition> assignedTopicPartitions, IRestrictedConsumer consumer);
@@ -55,11 +50,6 @@ namespace Akka.Streams.Kafka.Helpers
             {
             }
 
-            /// <inheritdoc />
-            public void OnLost(IImmutableSet<TopicPartitionOffset> revokedTopicPartitions, IRestrictedConsumer consumer)
-            {
-            }
-            
             /// <inheritdoc />
             public void OnAssign(IImmutableSet<TopicPartition> assignedTopicPartitions, IRestrictedConsumer consumer)
             {
@@ -93,12 +83,6 @@ namespace Akka.Streams.Kafka.Helpers
             }
 
             /// <inheritdoc />
-            public void OnLost(IImmutableSet<TopicPartitionOffset> revokedTopicPartitions, IRestrictedConsumer consumer)
-            {
-                OnRevoke(revokedTopicPartitions, consumer);
-            }
-            
-            /// <inheritdoc />
             public void OnAssign(IImmutableSet<TopicPartition> assignedTopicPartitions, IRestrictedConsumer consumer)
             {
                 _partitionAssignedCallback(assignedTopicPartitions);
@@ -131,13 +115,6 @@ namespace Akka.Streams.Kafka.Helpers
                 _handler2?.OnRevoke(revokedTopicPartitions, consumer);
             }
 
-            /// <inheritdoc />
-            public void OnLost(IImmutableSet<TopicPartitionOffset> revokedTopicPartitions, IRestrictedConsumer consumer)
-            {
-                _handler1?.OnLost(revokedTopicPartitions, consumer);
-                _handler2?.OnLost(revokedTopicPartitions, consumer);
-            }
-            
             /// <inheritdoc />
             public void OnAssign(IImmutableSet<TopicPartition> assignedTopicPartitions, IRestrictedConsumer consumer)
             {

--- a/src/Akka.Streams.Kafka/Settings/ConsumerSettings.cs
+++ b/src/Akka.Streams.Kafka/Settings/ConsumerSettings.cs
@@ -394,6 +394,7 @@ namespace Akka.Streams.Kafka.Settings
         public Confluent.Kafka.IConsumer<TKey, TValue> CreateKafkaConsumer(Action<IConsumer<TKey, TValue>, Error> consumeErrorHandler = null,
                                                                            Action<IConsumer<TKey, TValue>, List<TopicPartition>> partitionAssignedHandler = null,
                                                                            Action<IConsumer<TKey, TValue>, List<TopicPartitionOffset>> partitionRevokedHandler = null,
+                                                                           Action<IConsumer<TKey, TValue>, List<TopicPartitionOffset>> partitionLostHandler = null,
                                                                            Action<IConsumer<TKey, TValue>, string> statisticHandler = null)
         {
             RebalanceListener = new RebalanceListener<TKey, TValue>(
@@ -409,6 +410,7 @@ namespace Akka.Streams.Kafka.Settings
                 .SetErrorHandler((c, e) => consumeErrorHandler?.Invoke(c, e))
                 .SetPartitionsAssignedHandler((c, partitions) => partitionAssignedHandler?.Invoke(c, partitions))
                 .SetPartitionsRevokedHandler((c, partitions) => partitionRevokedHandler?.Invoke(c, partitions))
+                .SetPartitionsLostHandler((c, partitions) => partitionLostHandler?.Invoke(c, partitions))
                 .SetStatisticsHandler((c, json) => statisticHandler?.Invoke(c, json))
                 .Build();
         }

--- a/src/Akka.Streams.Kafka/Settings/ConsumerSettings.cs
+++ b/src/Akka.Streams.Kafka/Settings/ConsumerSettings.cs
@@ -394,11 +394,13 @@ namespace Akka.Streams.Kafka.Settings
         public Confluent.Kafka.IConsumer<TKey, TValue> CreateKafkaConsumer(Action<IConsumer<TKey, TValue>, Error> consumeErrorHandler = null,
                                                                            Action<IConsumer<TKey, TValue>, List<TopicPartition>> partitionAssignedHandler = null,
                                                                            Action<IConsumer<TKey, TValue>, List<TopicPartitionOffset>> partitionRevokedHandler = null,
+                                                                           Action<IConsumer<TKey, TValue>, List<TopicPartitionOffset>> partitionLostHandler = null,
                                                                            Action<IConsumer<TKey, TValue>, string> statisticHandler = null)
         {
             RebalanceListener = new RebalanceListener<TKey, TValue>(
                 onPartitionAssigned: partitionAssignedHandler,
-                onPartitionRevoked: partitionRevokedHandler);
+                onPartitionRevoked: partitionRevokedHandler,
+                onPartitionLost: partitionLostHandler);
 
             if (this.ConsumerFactory != null)
                 return this.ConsumerFactory(this);
@@ -409,6 +411,7 @@ namespace Akka.Streams.Kafka.Settings
                 .SetErrorHandler((c, e) => consumeErrorHandler?.Invoke(c, e))
                 .SetPartitionsAssignedHandler((c, partitions) => partitionAssignedHandler?.Invoke(c, partitions))
                 .SetPartitionsRevokedHandler((c, partitions) => partitionRevokedHandler?.Invoke(c, partitions))
+                .SetPartitionsLostHandler((c, partitions) => partitionLostHandler?.Invoke(c, partitions))
                 .SetStatisticsHandler((c, json) => statisticHandler?.Invoke(c, json))
                 .Build();
         }
@@ -416,13 +419,18 @@ namespace Akka.Streams.Kafka.Settings
 
     internal sealed class RebalanceListener<TKey, TValue>
     {
-        public RebalanceListener(Action<IConsumer<TKey, TValue>, List<TopicPartition>> onPartitionAssigned, Action<IConsumer<TKey, TValue>, List<TopicPartitionOffset>> onPartitionRevoked)
+        public RebalanceListener(
+            Action<IConsumer<TKey, TValue>, List<TopicPartition>> onPartitionAssigned, 
+            Action<IConsumer<TKey, TValue>, List<TopicPartitionOffset>> onPartitionRevoked, 
+            Action<IConsumer<TKey, TValue>, List<TopicPartitionOffset>> onPartitionLost)
         {
             OnPartitionAssigned = onPartitionAssigned;
             OnPartitionRevoked = onPartitionRevoked;
+            OnPartitionLost = onPartitionLost;
         }
 
         public Action<IConsumer<TKey, TValue>, List<TopicPartition>> OnPartitionAssigned { get; } 
         public Action<IConsumer<TKey, TValue>, List<TopicPartitionOffset>> OnPartitionRevoked { get; }
+        public Action<IConsumer<TKey, TValue>, List<TopicPartitionOffset>> OnPartitionLost { get; }
     }
 }

--- a/src/Akka.Streams.Kafka/Settings/ConsumerSettings.cs
+++ b/src/Akka.Streams.Kafka/Settings/ConsumerSettings.cs
@@ -394,7 +394,6 @@ namespace Akka.Streams.Kafka.Settings
         public Confluent.Kafka.IConsumer<TKey, TValue> CreateKafkaConsumer(Action<IConsumer<TKey, TValue>, Error> consumeErrorHandler = null,
                                                                            Action<IConsumer<TKey, TValue>, List<TopicPartition>> partitionAssignedHandler = null,
                                                                            Action<IConsumer<TKey, TValue>, List<TopicPartitionOffset>> partitionRevokedHandler = null,
-                                                                           Action<IConsumer<TKey, TValue>, List<TopicPartitionOffset>> partitionLostHandler = null,
                                                                            Action<IConsumer<TKey, TValue>, string> statisticHandler = null)
         {
             RebalanceListener = new RebalanceListener<TKey, TValue>(
@@ -410,7 +409,6 @@ namespace Akka.Streams.Kafka.Settings
                 .SetErrorHandler((c, e) => consumeErrorHandler?.Invoke(c, e))
                 .SetPartitionsAssignedHandler((c, partitions) => partitionAssignedHandler?.Invoke(c, partitions))
                 .SetPartitionsRevokedHandler((c, partitions) => partitionRevokedHandler?.Invoke(c, partitions))
-                .SetPartitionsLostHandler((c, partitions) => partitionLostHandler?.Invoke(c, partitions))
                 .SetStatisticsHandler((c, json) => statisticHandler?.Invoke(c, json))
                 .Build();
         }

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/SingleSourceStageLogic.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/SingleSourceStageLogic.cs
@@ -58,8 +58,9 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
         {
             var partitionsAssignedHandler = GetAsyncCallback<IEnumerable<TopicPartition>>(PartitionsAssigned);
             var partitionsRevokedHandler = GetAsyncCallback<IEnumerable<TopicPartitionOffset>>(PartitionsRevoked);
+            var partitionsLostHandler = GetAsyncCallback<IEnumerable<TopicPartitionOffset>>(PartitionsLost);
 
-            IPartitionEventHandler internalHandler = new PartitionEventHandlers.AsyncCallbacks(partitionsAssignedHandler, partitionsRevokedHandler);
+            IPartitionEventHandler internalHandler = new PartitionEventHandlers.AsyncCallbacks(partitionsAssignedHandler, partitionsRevokedHandler, partitionsLostHandler);
 
             // If custom partition events handler specified - add it to the chain
             var eventHandler = _subscription is IAutoSubscription autoSubscription && autoSubscription.PartitionEventsHandler.HasValue
@@ -144,6 +145,12 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
         {
             TopicPartitions = TopicPartitions.Except(partitions.Select(tpo => tpo.TopicPartition));
             Log.Debug("Partitions were revoked");
+        }
+        
+        private void PartitionsLost(IEnumerable<TopicPartitionOffset> partitions)
+        {
+            TopicPartitions = TopicPartitions.Except(partitions.Select(tpo => tpo.TopicPartition));
+            Log.Debug("Partitions were lost");
         }
     }
 }

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/SubSourceLogic.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/SubSourceLogic.cs
@@ -63,6 +63,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
         private readonly Action<IImmutableSet<TopicPartition>> _partitionAssignedCallback;
         private readonly Action<IImmutableSet<TopicPartition>> _updatePendingPartitionsAndEmitSubSourcesCallback;
         private readonly Action<IImmutableSet<TopicPartitionOffset>> _partitionRevokedCallback;
+        private readonly Action<IImmutableSet<TopicPartitionOffset>> _partitionLostCallback;
         private readonly Action<(TopicPartition, ISubSourceCancellationStrategy)> _subsourceCancelledCallback;
         private readonly Action<(TopicPartition, IControl)> _subsourceStartedCallback;
         private readonly Action<(IImmutableSet<TopicPartition>, IImmutableSet<TopicPartitionOffset>)> _offsetsFromExternalResponseCb;
@@ -115,6 +116,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
             _updatePendingPartitionsAndEmitSubSourcesCallback = GetAsyncCallback<IImmutableSet<TopicPartition>>(UpdatePendingPartitionsAndEmitSubSources);
             _partitionAssignedCallback = GetAsyncCallback<IImmutableSet<TopicPartition>>(HandlePartitionsAssigned);
             _partitionRevokedCallback = GetAsyncCallback<IImmutableSet<TopicPartitionOffset>>(HandlePartitionsRevoked);
+            _partitionLostCallback = GetAsyncCallback<IImmutableSet<TopicPartitionOffset>>(HandlePartitionsLost);
             _stageFailCallback = GetAsyncCallback<ConsumerFailed>(FailStage);
             _subsourceCancelledCallback = GetAsyncCallback<(TopicPartition, ISubSourceCancellationStrategy)>(HandleSubsourceCancelled);
             _subsourceStartedCallback = GetAsyncCallback<(TopicPartition, IControl)>(HandleSubsourceStarted);
@@ -144,7 +146,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
             if (!(Materializer is ActorMaterializer actorMaterializer))
                 throw new ArgumentException($"Expected {typeof(ActorMaterializer)} but got {Materializer.GetType()}");
 
-            var eventHandler = new PartitionEventHandlers.AsyncCallbacks(_partitionAssignedCallback, _partitionRevokedCallback);
+            var eventHandler = new PartitionEventHandlers.AsyncCallbacks(_partitionAssignedCallback, _partitionRevokedCallback, _partitionLostCallback);
 
             var statisticsHandler = _subscription.StatisticsHandler.HasValue
                 ? _subscription.StatisticsHandler.Value
@@ -269,6 +271,13 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
         }
 
         private void HandlePartitionsRevoked(IImmutableSet<TopicPartitionOffset> revoked)
+        {
+            _partitionsToRevoke = _partitionsToRevoke.Union(revoked.Select(r => r.TopicPartition));
+
+            ScheduleOnce(new CloseRevokedPartitions(), _settings.WaitClosePartition);
+        }
+
+        private void HandlePartitionsLost(IImmutableSet<TopicPartitionOffset> revoked)
         {
             _partitionsToRevoke = _partitionsToRevoke.Union(revoked.Select(r => r.TopicPartition));
 

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/TransactionalSourceLogic.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/TransactionalSourceLogic.cs
@@ -144,21 +144,24 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
         {
             var blockingRevokedCall = new PartitionEventHandlers.AsyncCallbacks(
                 partitionAssignedCallback: _ => { },
-                partitionRevokedCallback: revokedTopicPartitions =>
-                {
-                    var topicPartitions = revokedTopicPartitions.Select(tp => tp.TopicPartition).ToImmutableHashSet();
-                    if (WaitForDraining(topicPartitions))
-                    {
-                        SourceActor.Ref.Tell(new KafkaConsumerActorMetadata.Internal.Revoked(topicPartitions));
-                    }
-                    else
-                    {
-                        SourceActor.Ref.Tell(new Status.Failure(new Exception("Timeout while drailing")));
-                        ConsumerActor.Tell(KafkaConsumerActorMetadata.Internal.Stop.Instance);
-                    }
-                });
+                partitionRevokedCallback: OnRevoke,
+                partitionLostCallback: OnRevoke);
             
             return new PartitionEventHandlers.Chain(handler, blockingRevokedCall);
+
+            void OnRevoke(IImmutableSet<TopicPartitionOffset> revokedTopicPartitions)
+            {
+                var topicPartitions = revokedTopicPartitions.Select(tp => tp.TopicPartition).ToImmutableHashSet();
+                if (WaitForDraining(topicPartitions))
+                {
+                    SourceActor.Ref.Tell(new KafkaConsumerActorMetadata.Internal.Revoked(topicPartitions));
+                }
+                else
+                {
+                    SourceActor.Ref.Tell(new Status.Failure(new Exception("Timeout while drailing")));
+                    ConsumerActor.Tell(KafkaConsumerActorMetadata.Internal.Stop.Instance);
+                }
+            }
         }
 
         private bool WaitForDraining(IImmutableSet<TopicPartition> partitions)

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
@@ -82,7 +82,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
         /// While `true`, committing is delayed.
         /// Changed by `onPartitionsRevoked` and `onPartitionsAssigned` callbacks
         /// </summary>
-        private bool _rebalanceInProgress = false;
+        private AtomicBoolean _rebalanceInProgress = new();
         /// <summary>
         /// Keeps commit offsets during rebalances for later commit.
         /// </summary>
@@ -122,7 +122,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
         private void PartitionsAssignedHandler(IImmutableSet<TopicPartition> partitions)
         {
             var assignment = _consumer.Assignment;
-            var partitionsToPause = partitions.Where(p => assignment.Contains(p)).ToList();
+            var partitionsToPause = partitions.Where(p => assignment.Contains(p)).ToImmutableList();
             PausePartitions(partitionsToPause);
             
             _commitRefreshing.AssignedPositions(partitions, _consumer, _settings.PositionTimeout);
@@ -132,7 +132,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
             watch.Stop();
             CheckDuration(watch, "onAssign");
             
-            _rebalanceInProgress = false;
+            _rebalanceInProgress.GetAndSet(false);
         }
 
         // This is RebalanceListener.OnPartitionRevoked on JVM
@@ -144,12 +144,12 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
             CheckDuration(watch, "onRevoke");
             
             _commitRefreshing.Revoke(partitions.Select(tp => tp.TopicPartition).ToImmutableHashSet());
-            _rebalanceInProgress = true;
+            _rebalanceInProgress.GetAndSet(true);
         }
 
         private void RebalancePostStop()
         {
-            var currentTopicPartitions = _consumer.Assignment;
+            var currentTopicPartitions = _consumer.Assignment.ToImmutableList();
             PausePartitions(currentTopicPartitions);
             
             var watch = Stopwatch.StartNew();
@@ -299,6 +299,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                     consumeErrorHandler: (c, e) => ProcessExceptions(new KafkaException(e)),
                     partitionAssignedHandler: (c, tp) => PartitionsAssignedHandler(tp.ToImmutableHashSet()),
                     partitionRevokedHandler: (c, tp) => PartitionsRevokedHandler(tp.ToImmutableHashSet()),
+                    partitionLostHandler: (c, tp) => PartitionsLostHandler(tp.ToImmutableHashSet()),
                     statisticHandler: (c, json) => _statisticsHandler.OnStatistics(c, json));
 
                 if (_settings.ConnectionCheckerSettings.Enabled)
@@ -441,8 +442,8 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
 
         private void Poll()
         {
-            var currentAssignment = _consumer.Assignment;
-            var initialRebalanceInProcess = _rebalanceInProgress;
+            var currentAssignment = _consumer.Assignment.ToImmutableList();
+            var initialRebalanceInProcess = _rebalanceInProgress.Value;
 
             if (_requests.IsEmpty())
             {
@@ -482,8 +483,8 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                 
                 // resume partitions to fetch
                 IImmutableSet<TopicPartition> partitionsToFetch = _requests.Values.SelectMany(v => v.Topics).ToImmutableHashSet();
-                var resumeThese = currentAssignment.Where(partitionsToFetch.Contains).ToList();
-                var pauseThese = currentAssignment.Except(resumeThese).ToList();
+                var resumeThese = currentAssignment.Where(partitionsToFetch.Contains).ToImmutableList();
+                var pauseThese = currentAssignment.Except(resumeThese).ToImmutableList();
                 PausePartitions(pauseThese);
                 ResumePartitions(resumeThese);
 
@@ -647,7 +648,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
         /// </summary>
         private void CheckRebalanceState(bool initialRebalanceInProgress)
         {
-            if (initialRebalanceInProgress && !_rebalanceInProgress && _rebalanceCommitSenders.Any())
+            if (initialRebalanceInProgress && !_rebalanceInProgress.Value && _rebalanceCommitSenders.Any())
             {
                 _log.Debug($"Comitting stash {string.Join(", ", _rebalanceCommitStash)} replying to {string.Join(", ", _rebalanceCommitSenders)}");
                 var replyTo = _rebalanceCommitSenders;
@@ -657,7 +658,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
             }
         }
 
-        private void PausePartitions(List<TopicPartition> partitions)
+        private void PausePartitions(IImmutableList<TopicPartition> partitions)
         {
             if (partitions.Count == 0)
                 return;
@@ -668,7 +669,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
             _resumedPartitions = _resumedPartitions.Except(partitions);
         }
 
-        private void ResumePartitions(List<TopicPartition> partitions)
+        private void ResumePartitions(IImmutableList<TopicPartition> partitions)
         {
             if (partitions.Count == 0)
                 return;

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
@@ -687,6 +687,12 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                 return;
             
             var partitionsToResume = partitions.Except(_resumedPartitions).ToList();
+            if(partitionsToResume.Count == 0 && _log.IsDebugEnabled)
+            {
+                _log.Debug("Requested partitions already resumed. Resume request: [{0}], already resumed: [{1}]", string.Join(",", partitions), string.Join(",", _resumedPartitions));
+                return;
+            }
+            
             if(_log.IsDebugEnabled)
                 _log.Debug("Resuming partitions [{0}]", string.Join(",", partitionsToResume));
             _consumer.Resume(partitionsToResume);

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
@@ -118,27 +118,6 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
         }
 
         #region Rebalance listener
-        
-        internal sealed class PartitionAssigned
-        {
-            public PartitionAssigned(IImmutableSet<TopicPartition> partitions)
-            {
-                Partitions = partitions;
-            }
-
-            public IImmutableSet<TopicPartition> Partitions { get; }
-        }
-        
-        internal sealed class PartitionRevoked
-        {
-            public PartitionRevoked(IImmutableSet<TopicPartitionOffset> partitions)
-            {
-                Partitions = partitions;
-            }
-
-            public IImmutableSet<TopicPartitionOffset> Partitions { get; }
-        }
-    
         // This is RebalanceListener.OnPartitionAssigned on JVM
         private void PartitionsAssignedHandler(IImmutableSet<TopicPartition> partitions)
         {
@@ -283,19 +262,6 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
 
                 case Metadata.IRequest req:
                     Sender.Tell(HandleMetadataRequest(req));
-                    return true;
-                
-                // Rebalance callbacks
-                case PartitionAssigned evt:
-                    PartitionsAssignedHandler(evt.Partitions);
-                    return true;
-                
-                case PartitionRevoked evt:
-                    PartitionsRevokedHandler(evt.Partitions);
-                    return true;
-                
-                case Status.Failure fail:
-                    ProcessExceptions(fail.Cause);
                     return true;
                 
                 default:

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
@@ -147,6 +147,17 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
             _rebalanceInProgress.GetAndSet(true);
         }
 
+        // This is RebalanceListener.OnPartitionsLost on JVM
+        private void PartitionsLostHandler(IImmutableSet<TopicPartitionOffset> partitions)
+        {
+            var watch = Stopwatch.StartNew();
+            _partitionEventHandler.OnLost(partitions, _restrictedConsumer);
+            watch.Stop();
+            CheckDuration(watch, "onLost");
+            
+            _commitRefreshing.Revoke(partitions.Select(tp => tp.TopicPartition).ToImmutableHashSet());
+        }
+
         private void RebalancePostStop()
         {
             var currentTopicPartitions = _consumer.Assignment.ToImmutableList();
@@ -490,17 +501,15 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
 
                 using (var cts = new CancellationTokenSource(_settings.PollTimeout))
                 {
-                    var (polled, exception) = PollKafka(cts.Token);
                     try
                     {
+                        var polled = PollKafka(cts.Token);
                         ProcessResult(partitionsToFetch, polled);
                     }
                     catch (Exception e)
                     {
                         ProcessExceptions(e);
                     }
-
-                    ProcessExceptions(exception);
                 }
             }
             
@@ -529,7 +538,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
             Context.Stop(Self);
         }
 
-        private (List<ConsumeResult<K, V>>, Exception) PollKafka(CancellationToken token)
+        private List<ConsumeResult<K, V>> PollKafka(CancellationToken token)
         {
             ConsumeResult<K, V> consumed = null;
             var i = 10; // 10 poll attempts
@@ -537,21 +546,12 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
             var polled = new List<ConsumeResult<K, V>>();
             do
             {
-                try
-                {
-                    // this would return immediately if there are messages waiting inside the client queue buffer
-                    consumed = _consumer.Consume(timeout);
-                }
-                catch (Exception e)
-                {
-                    return (polled, e);
-                }
-                if (consumed != null)
-                    polled.Add(consumed);
+                // this would return immediately if there are messages waiting inside the client queue buffer
+                consumed = _consumer.Consume(timeout);
                 i--;
             } while (i > 0 && consumed != null && !token.IsCancellationRequested);
 
-            return (polled, null);
+            return polled;
         }
 
         private void ProcessResult(IImmutableSet<TopicPartition> partitionsToFetch, List<ConsumeResult<K,V>> rawResult)

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
@@ -329,11 +329,10 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                 if (_log.IsDebugEnabled)
                     _log.Debug($"Creating Kafka consumer with settings: {JsonConvert.SerializeObject(_settings)}");
 
-                var localSelf = Self;
                 _consumer = _settings.CreateKafkaConsumer(
-                    consumeErrorHandler: (c, e) => localSelf.Tell(new Status.Failure(new KafkaException(e))),
-                    partitionAssignedHandler: (c, tp) => localSelf.Tell(new PartitionAssigned(tp.ToImmutableHashSet())),
-                    partitionRevokedHandler: (c, tp) => localSelf.Tell(new PartitionRevoked(tp.ToImmutableHashSet())),
+                    consumeErrorHandler: (c, e) => ProcessExceptions(new KafkaException(e)),
+                    partitionAssignedHandler: (c, tp) => PartitionsAssignedHandler(tp.ToImmutableHashSet()),
+                    partitionRevokedHandler: (c, tp) => PartitionsRevokedHandler(tp.ToImmutableHashSet()),
                     statisticHandler: (c, json) => _statisticsHandler.OnStatistics(c, json));
 
                 if (_settings.ConnectionCheckerSettings.Enabled)

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
@@ -659,6 +659,9 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
 
         private void PausePartitions(List<TopicPartition> partitions)
         {
+            if (partitions.Count == 0)
+                return;
+            
             if(_log.IsDebugEnabled)
                 _log.Debug("Pausing partitions [{0}]", string.Join(",", partitions));
             _consumer.Pause(partitions);
@@ -667,6 +670,9 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
 
         private void ResumePartitions(List<TopicPartition> partitions)
         {
+            if (partitions.Count == 0)
+                return;
+            
             var partitionsToResume = partitions.Except(_resumedPartitions).ToList();
             if(_log.IsDebugEnabled)
                 _log.Debug("Resuming partitions [{0}]", string.Join(",", partitionsToResume));

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
@@ -147,6 +147,18 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
             _rebalanceInProgress.GetAndSet(true);
         }
 
+        // This is RebalanceListener.OnPartitionLost on JVM
+        private void PartitionsLostHandler(IImmutableSet<TopicPartitionOffset> partitions)
+        {
+            var watch = Stopwatch.StartNew();
+            _partitionEventHandler.OnLost(partitions, _restrictedConsumer);
+            watch.Stop();
+            CheckDuration(watch, "onLost");
+            
+            _commitRefreshing.Revoke(partitions.Select(tp => tp.TopicPartition).ToImmutableHashSet());
+            _rebalanceInProgress.GetAndSet(true);
+        }
+        
         private void RebalancePostStop()
         {
             var currentTopicPartitions = _consumer.Assignment.ToImmutableList();

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
@@ -147,17 +147,6 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
             _rebalanceInProgress.GetAndSet(true);
         }
 
-        // This is RebalanceListener.OnPartitionsLost on JVM
-        private void PartitionsLostHandler(IImmutableSet<TopicPartitionOffset> partitions)
-        {
-            var watch = Stopwatch.StartNew();
-            _partitionEventHandler.OnLost(partitions, _restrictedConsumer);
-            watch.Stop();
-            CheckDuration(watch, "onLost");
-            
-            _commitRefreshing.Revoke(partitions.Select(tp => tp.TopicPartition).ToImmutableHashSet());
-        }
-
         private void RebalancePostStop()
         {
             var currentTopicPartitions = _consumer.Assignment.ToImmutableList();
@@ -501,15 +490,17 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
 
                 using (var cts = new CancellationTokenSource(_settings.PollTimeout))
                 {
+                    var (polled, exception) = PollKafka(cts.Token);
                     try
                     {
-                        var polled = PollKafka(cts.Token);
                         ProcessResult(partitionsToFetch, polled);
                     }
                     catch (Exception e)
                     {
                         ProcessExceptions(e);
                     }
+
+                    ProcessExceptions(exception);
                 }
             }
             
@@ -538,7 +529,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
             Context.Stop(Self);
         }
 
-        private List<ConsumeResult<K, V>> PollKafka(CancellationToken token)
+        private (List<ConsumeResult<K, V>>, Exception) PollKafka(CancellationToken token)
         {
             ConsumeResult<K, V> consumed = null;
             var i = 10; // 10 poll attempts
@@ -546,12 +537,21 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
             var polled = new List<ConsumeResult<K, V>>();
             do
             {
-                // this would return immediately if there are messages waiting inside the client queue buffer
-                consumed = _consumer.Consume(timeout);
+                try
+                {
+                    // this would return immediately if there are messages waiting inside the client queue buffer
+                    consumed = _consumer.Consume(timeout);
+                }
+                catch (Exception e)
+                {
+                    return (polled, e);
+                }
+                if (consumed != null)
+                    polled.Add(consumed);
                 i--;
             } while (i > 0 && consumed != null && !token.IsCancellationRequested);
 
-            return polled;
+            return (polled, null);
         }
 
         private void ProcessResult(IImmutableSet<TopicPartition> partitionsToFetch, List<ConsumeResult<K,V>> rawResult)


### PR DESCRIPTION
Possible fix for #414 and #415

## Changes

* Refactor KafkaConsumerActor event handling from using `Self.Tell()` to direct method call
* Implement missing OnPartitionsLost handler
