### PR TITLE
Make sure that we prevent downstream to propagate null completion exception

### DIFF
--- a/src/Akka.Streams.Kafka/Stages/DownstreamFinishedWithNoCauseException.cs
+++ b/src/Akka.Streams.Kafka/Stages/DownstreamFinishedWithNoCauseException.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace Akka.Streams.Kafka.Stages;
+
+public class DownstreamFinishedWithNoCauseException: Exception
+{
+    public override string Message => "Downstream flow or stage completed with no cause";
+}

--- a/src/Akka.Streams.Kafka/Stages/Producers/DefaultProducerStage.cs
+++ b/src/Akka.Streams.Kafka/Stages/Producers/DefaultProducerStage.cs
@@ -153,10 +153,30 @@ namespace Akka.Streams.Kafka.Stages
                     CheckForCompletion();
                 });
 
-            SetHandler(_stage.Out, onPull: () =>
-            {
-                TryPull(_stage.In);
-            });
+            SetHandler(
+                outlet: _stage.Out, 
+                onPull: () =>
+                {
+                    TryPull(_stage.In);
+                }, 
+                onDownstreamFinish: ex =>
+                {
+                    if (ex is null)
+                    {
+                        try
+                        {
+                            throw new DownstreamFinishedWithNoCauseException();
+                        }
+                        catch(DownstreamFinishedWithNoCauseException e)
+                        {
+                            InternalOnDownstreamFinish(e);
+                        }
+                    }
+                    else
+                    {
+                        InternalOnDownstreamFinish(ex);
+                    }
+                });
         }
 
         public override void PreStart()


### PR DESCRIPTION
Fixes #426

## Changes

Make sure that `DefaultProducerStage` never pass a null completion exception to `InternalOnDownstreamFinish`

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).

### Latest `dev` Benchmarks 

Include data from the [relevant benchmark](https://getakka.net/community/contributing/index.html#improve-performance) prior to this change here.

### This PR's Benchmarks

Include data from after this change here.
