### PR TITLE
Refactor `SubSourceStageLogic`; filter messages from revoked partitions in partitioned stream sources

### DIFF
--- a/src/Akka.Streams.Kafka.Tests/Integration/RebalanceIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/RebalanceIntegrationTests.cs
@@ -118,7 +118,7 @@ public class RebalanceIntegrationTests : KafkaIntegrationTests
         // Assert.True(control2.IsShutdown.IsCompleted);
     }
 
-    [Fact(Skip = "Filtering is not enabled on sub-sources just yet")]
+    [Fact]
     public async Task FetchedRecords_must_be_removed_from_the_partitioned_source_stage_when_a_partition_is_revoked()
     {
         const int count = 20;

--- a/src/Akka.Streams.Kafka/Extensions/CollectionExtensions.cs
+++ b/src/Akka.Streams.Kafka/Extensions/CollectionExtensions.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace Akka.Streams.Kafka.Extensions
 {
-    public static class CollectionExtensions
+    internal static class CollectionExtensions
     {
         /// <summary>
         /// Joins elements of the collection with given separator to single string

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/SubSourceLogic.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/SubSourceLogic.cs
@@ -44,13 +44,25 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
         public static readonly ISubSourceCancellationStrategy Instance = new DoNothing();
         private DoNothing() {}
     }
+
+    /// <summary>
+    /// INTERNAL API
+    /// </summary>
+    internal static class SubSourceLogicHelpers
+    {
+        public sealed class CloseRevokedPartitions
+        {
+            public static readonly CloseRevokedPartitions Instance = new();
+            private CloseRevokedPartitions(){}
+        }
+    }
     
     /// <summary>
     /// Stage logic used to produce sub-sources per topic partitions
     /// </summary>
     internal class SubSourceLogic<K, V, TMessage> : TimerGraphStageLogic
     {
-        private class CloseRevokedPartitions { }
+        
 
         private readonly SourceShape<(TopicPartition, Source<TMessage, NotUsed>)> _shape;
         private readonly ConsumerSettings<K, V> _settings;
@@ -206,7 +218,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
 
         protected override void OnTimer(object timerKey)
         {
-            if (timerKey is CloseRevokedPartitions)
+            if (timerKey is SubSourceLogicHelpers.CloseRevokedPartitions)
             {
                 Log.Debug("#{0} Closing SubSources for revoked partitions: {1}", _actorNumber, _partitionsToRevoke.JoinToString(", "));
 
@@ -298,7 +310,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
         {
             _partitionsToRevoke = _partitionsToRevoke.Union(revoked.Select(r => r.TopicPartition));
 
-            ScheduleOnce(new CloseRevokedPartitions(), _settings.WaitClosePartition);
+            ScheduleOnce(SubSourceLogicHelpers.CloseRevokedPartitions.Instance, _settings.WaitClosePartition);
         }
 
         private void HandleSubsourceCancelled((TopicPartition, ISubSourceCancellationStrategy) obj)

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/SubSourceLogic.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/SubSourceLogic.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using Akka.Actor;
-using Akka.Event;
 using Akka.Streams.Dsl;
 using Akka.Streams.Kafka.Extensions;
 using Akka.Streams.Kafka.Helpers;
@@ -30,9 +29,17 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
         public sealed class CloseRevokedPartitions
         {
             public static readonly CloseRevokedPartitions Instance = new();
-            private CloseRevokedPartitions(){}
+
+            private CloseRevokedPartitions()
+            {
+            }
         }
-        
+
+        /// <summary>
+        /// Used to determine how the <see cref="SubSourceLogic{K,V,TMessage}"/> will handle the cancellation of
+        /// a sub source stage. The default behavior requested by the <see cref="SubSourceStageLogic{K,V,TMessage}"/> is to ask
+        /// the consumer to seek to the last committed offset and then re-emit the sub source stage downstream.
+        /// </summary>
         internal interface ISubSourceCancellationStrategy;
 
         internal sealed record SeekToOffsetAndReEmit(long Offset) : ISubSourceCancellationStrategy;
@@ -40,28 +47,61 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
         internal sealed class ReEmit : ISubSourceCancellationStrategy
         {
             public static readonly ISubSourceCancellationStrategy Instance = new ReEmit();
-            private ReEmit() {}
+
+            private ReEmit()
+            {
+            }
         }
 
         internal sealed class DoNothing : ISubSourceCancellationStrategy
         {
             public static readonly ISubSourceCancellationStrategy Instance = new DoNothing();
-            private DoNothing() {}
+
+            private DoNothing()
+            {
+            }
+        }
+
+        /// <summary>
+        /// INTERNAL API
+        /// </summary>
+        /// <param name="Control">Control for SubSourceStageLogic</param>
+        /// <param name="StageActor">Actor for the SubSourceStageLogic</param>
+        public sealed record ControlAndStageActor(IControl Control, IActorRef StageActor);
+
+        public sealed record SubSourceStageLogicControl(
+            TopicPartition TopicPartition,
+            ControlAndStageActor ControlAndStageActor,
+            Action<IImmutableSet<TopicPartitionOffset>> FilterRevokedPartitionsCb);
+
+        /// <summary>
+        /// Factory method to create a <see cref="SubSourceStageLogic{K,V,TMessage}"/> within
+        /// <see cref="SubSourceLogic{K,V,TMessage}"/> where the context parameters exist.
+        /// </summary>
+        public interface ISubSourceStageLogicFactory<K, V, TMessage>
+        {
+            SubSourceStageLogic<K, V, TMessage> Create(SourceShape<TMessage> shape, TopicPartition tp,
+                IActorRef consumerActor,
+                Action<SubSourceStageLogicControl> subSourceStartedCb,
+                Action<(TopicPartition partition, ISubSourceCancellationStrategy cancellationStrategy)>
+                    subSourceCancelledCb,
+                int actorNumber);
         }
     }
-    
+
     /// <summary>
     /// Stage logic used to produce sub-sources per topic partitions
     /// </summary>
     internal class SubSourceLogic<K, V, TMessage> : TimerGraphStageLogic
     {
-        
-
         private readonly SourceShape<(TopicPartition, Source<TMessage, NotUsed>)> _shape;
         private readonly ConsumerSettings<K, V> _settings;
         private readonly IAutoSubscription _subscription;
         private readonly IMessageBuilder<K, V, TMessage> _messageBuilder;
-        private readonly Option<Func<IImmutableSet<TopicPartition>, Task<IImmutableSet<TopicPartitionOffset>>>> _getOffsetsOnAssign;
+
+        private readonly Option<Func<IImmutableSet<TopicPartition>, Task<IImmutableSet<TopicPartitionOffset>>>>
+            _getOffsetsOnAssign;
+
         private readonly Action<IImmutableSet<TopicPartition>> _onRevoke;
 
         private readonly int _actorNumber = KafkaConsumerActorMetadata.NextNumber();
@@ -70,7 +110,10 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
         private readonly Action<IImmutableSet<TopicPartitionOffset>> _partitionRevokedCallback;
         private readonly Action<(TopicPartition, ISubSourceCancellationStrategy)> _subsourceCancelledCallback;
         private readonly Action<(TopicPartition, IControl)> _subsourceStartedCallback;
-        private readonly Action<(IImmutableSet<TopicPartition>, IImmutableSet<TopicPartitionOffset>)> _offsetsFromExternalResponseCb;
+
+        private readonly Action<(IImmutableSet<TopicPartition>, IImmutableSet<TopicPartitionOffset>)>
+            _offsetsFromExternalResponseCb;
+
         private readonly Action<ConsumerFailed> _stageFailCallback;
         private readonly Decider _decider;
 
@@ -83,7 +126,9 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
         /// We have created a source for these partitions, but it has not started up and is not in subSources yet.
         /// </summary>
         private IImmutableSet<TopicPartition> _partitionsInStartup = ImmutableHashSet<TopicPartition>.Empty;
-        private IImmutableDictionary<TopicPartition, IControl> _subSources = ImmutableDictionary<TopicPartition, IControl>.Empty;
+
+        private IImmutableDictionary<TopicPartition, IControl> _subSources =
+            ImmutableDictionary<TopicPartition, IControl>.Empty;
 
         /// <summary>
         /// Kafka has signalled these partitions are revoked, but some may be re-assigned just after revoking.
@@ -98,10 +143,12 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
         /// <summary>
         /// SubSourceLogic
         /// </summary>
-        public SubSourceLogic(SourceShape<(TopicPartition, Source<TMessage, NotUsed>)> shape, ConsumerSettings<K, V> settings,
-                              IAutoSubscription subscription, Func<SubSourceLogic<K, V, TMessage>, IMessageBuilder<K, V, TMessage>> messageBuilderFactory,
-                              Option<Func<IImmutableSet<TopicPartition>, Task<IImmutableSet<TopicPartitionOffset>>>> getOffsetsOnAssign,
-                              Action<IImmutableSet<TopicPartition>> onRevoke, Attributes attributes)
+        public SubSourceLogic(SourceShape<(TopicPartition, Source<TMessage, NotUsed>)> shape,
+            ConsumerSettings<K, V> settings,
+            IAutoSubscription subscription,
+            Func<SubSourceLogic<K, V, TMessage>, IMessageBuilder<K, V, TMessage>> messageBuilderFactory,
+            Option<Func<IImmutableSet<TopicPartition>, Task<IImmutableSet<TopicPartitionOffset>>>> getOffsetsOnAssign,
+            Action<IImmutableSet<TopicPartition>> onRevoke, Attributes attributes)
             : base(shape)
         {
             _shape = shape;
@@ -114,19 +161,24 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
             var supervisionStrategy = attributes.GetAttribute<ActorAttributes.SupervisionStrategy>();
             _decider = supervisionStrategy != null ? supervisionStrategy.Decider : Deciders.StoppingDecider;
 
-            Control = new SubSourcePromiseControl(_shape, Complete, SetKeepGoing, GetAsyncCallback, GetAsyncCallback, PerformStop, PerformShutdown);
+            Control = new SubSourcePromiseControl(_shape, Complete, SetKeepGoing, GetAsyncCallback, GetAsyncCallback,
+                PerformStop, PerformShutdown);
 
-            _updatePendingPartitionsAndEmitSubSourcesCallback = GetAsyncCallback<IImmutableSet<TopicPartition>>(UpdatePendingPartitionsAndEmitSubSources);
+            _updatePendingPartitionsAndEmitSubSourcesCallback =
+                GetAsyncCallback<IImmutableSet<TopicPartition>>(UpdatePendingPartitionsAndEmitSubSources);
             _partitionAssignedCallback = GetAsyncCallback<IImmutableSet<TopicPartition>>(HandlePartitionsAssigned);
             _partitionRevokedCallback = GetAsyncCallback<IImmutableSet<TopicPartitionOffset>>(HandlePartitionsRevoked);
             _stageFailCallback = GetAsyncCallback<ConsumerFailed>(FailStage);
-            _subsourceCancelledCallback = GetAsyncCallback<(TopicPartition, ISubSourceCancellationStrategy)>(HandleSubsourceCancelled);
+            _subsourceCancelledCallback =
+                GetAsyncCallback<(TopicPartition, ISubSourceCancellationStrategy)>(HandleSubsourceCancelled);
             _subsourceStartedCallback = GetAsyncCallback<(TopicPartition, IControl)>(HandleSubsourceStarted);
-            _offsetsFromExternalResponseCb = GetAsyncCallback<(IImmutableSet<TopicPartition>, IImmutableSet<TopicPartitionOffset>)>(OffsetsFromExternalResponseCallback);
+            _offsetsFromExternalResponseCb =
+                GetAsyncCallback<(IImmutableSet<TopicPartition>, IImmutableSet<TopicPartitionOffset>)>(
+                    OffsetsFromExternalResponseCallback);
 
             SetHandler(shape.Outlet, onPull: EmitSubSourcesForPendingPartitions, onDownstreamFinish: PerformShutdown);
         }
-        
+
         protected void ConfigureSubscription(Action<IImmutableSet<TopicPartition>> partitionsAssignedCb,
             Action<IImmutableSet<TopicPartitionOffset>> partitionsRevokedCb)
         {
@@ -152,11 +204,13 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
 
             IPartitionEventHandler CreateRebalanceListener(IAutoSubscription subscription)
             {
-                return new PartitionEventHandlers.Chain(subscription.PartitionEventsHandler.GetOrElse(PartitionEventHandlers.Empty.Instance), new PartitionEventHandlers.AsyncCallbacks(subscription, SourceActor.Ref, partitionsAssignedCb,
-                    partitionsRevokedCb));
+                return new PartitionEventHandlers.Chain(
+                    subscription.PartitionEventsHandler.GetOrElse(PartitionEventHandlers.Empty.Instance),
+                    new PartitionEventHandlers.AsyncCallbacks(subscription, SourceActor.Ref, partitionsAssignedCb,
+                        partitionsRevokedCb));
             }
         }
-        
+
         /// <summary>
         /// Opportunity for subclasses to add their logic to the partition assignment callbacks.
         /// </summary>
@@ -185,14 +239,14 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
 
             if (Materializer is not ActorMaterializer actorMaterializer)
                 throw new ArgumentException($"Expected {typeof(ActorMaterializer)} but got {Materializer.GetType()}");
-            
+
             var statisticsHandler = _subscription.StatisticsHandler.HasValue
                 ? _subscription.StatisticsHandler.Value
                 : StatisticsHandlers.Empty.Instance;
 
             var extendedActorSystem = actorMaterializer.System.AsInstanceOf<ExtendedActorSystem>();
             ConsumerActor = extendedActorSystem.SystemActorOf(
-                KafkaConsumerActorMetadata.GetProps(SourceActor.Ref, _settings, _decider, statisticsHandler), 
+                KafkaConsumerActorMetadata.GetProps(SourceActor.Ref, _settings, _decider, statisticsHandler),
                 $"kafka-consumer-{_actorNumber}");
 
             SourceActor.Watch(ConsumerActor);
@@ -203,7 +257,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
         public override void PostStop()
         {
             ConsumerActor.Tell(KafkaConsumerActorMetadata.Internal.Stop.Instance, SourceActor.Ref);
-            
+
             Control.OnShutdown();
 
             base.PostStop();
@@ -213,7 +267,8 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
         {
             if (timerKey is SubSourceLogic.CloseRevokedPartitions)
             {
-                Log.Debug("#{0} Closing SubSources for revoked partitions: {1}", _actorNumber, _partitionsToRevoke.JoinToString(", "));
+                Log.Debug("#{0} Closing SubSources for revoked partitions: {1}", _actorNumber,
+                    _partitionsToRevoke.JoinToString(", "));
 
                 _onRevoke(_partitionsToRevoke);
                 _pendingPartitions = _pendingPartitions.Except(_partitionsToRevoke);
@@ -250,7 +305,9 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
                 {
                     if (t.IsFaulted)
                     {
-                        _stageFailCallback(new ConsumerFailed($"{_actorNumber} Failed to fetch offset for partitions: {formerlyUnknown.JoinToString(", ")}", t.Exception));
+                        _stageFailCallback(new ConsumerFailed(
+                            $"{_actorNumber} Failed to fetch offset for partitions: {formerlyUnknown.JoinToString(", ")}",
+                            t.Exception));
                     }
                     else
                     {
@@ -260,7 +317,8 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
             }
         }
 
-        private void OffsetsFromExternalResponseCallback((IImmutableSet<TopicPartition>, IImmutableSet<TopicPartitionOffset>) result)
+        private void OffsetsFromExternalResponseCallback(
+            (IImmutableSet<TopicPartition>, IImmutableSet<TopicPartitionOffset>) result)
         {
             var (formerlyUnknown, offsets) = result;
             var updatedFormerlyUnknown =
@@ -269,23 +327,27 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
                 offsets.Where(o => !_partitionsToRevoke.Contains(o.TopicPartition)).ToImmutableHashSet());
         }
 
-        private void SeekAndEmitSubSources(IImmutableSet<TopicPartition> formerlyUnknown, IImmutableSet<TopicPartitionOffset> offsets)
+        private void SeekAndEmitSubSources(IImmutableSet<TopicPartition> formerlyUnknown,
+            IImmutableSet<TopicPartitionOffset> offsets)
         {
             ConsumerActor.Ask(new KafkaConsumerActorMetadata.Internal.Seek(offsets), TimeSpan.FromSeconds(10))
                 .ContinueWith(t =>
                 {
                     if (t.IsCanceled)
                     {
-                        _stageFailCallback(new ConsumerFailed($"{_actorNumber} Consumer failed during seek, task cancelled. Partitions: {offsets.JoinToString(", ")}"));
-                    } else if (t.IsFaulted)
+                        _stageFailCallback(new ConsumerFailed(
+                            $"{_actorNumber} Consumer failed during seek, task cancelled. Partitions: {offsets.JoinToString(", ")}"));
+                    }
+                    else if (t.IsFaulted)
                     {
-                        if(t.Exception == null)
+                        if (t.Exception == null)
                             throw new Exception(
                                 $"{_actorNumber} Consumer failed during seek, task faulted with null cause. Partitions: {offsets.JoinToString(", ")}");
-                        
+
                         if (t.Exception.Flatten().InnerExceptions.OfType<AskTimeoutException>().Any())
                         {
-                            _stageFailCallback(new ConsumerFailed($"{_actorNumber} Consumer failed during seek, Ask timed out. Partitions: {offsets.JoinToString(", ")}"));
+                            _stageFailCallback(new ConsumerFailed(
+                                $"{_actorNumber} Consumer failed during seek, Ask timed out. Partitions: {offsets.JoinToString(", ")}"));
                         }
                         else
                         {
@@ -319,11 +381,12 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
                     var offset = seek.Offset;
                     // re-add this partition to pending partitions so it can be re-emitted
                     _pendingPartitions = _pendingPartitions.Add(topicPartition);
-                    if(Log.IsDebugEnabled)
-                        Log.Debug("#{0} Seeking {1} to {2} after partition SubSource cancelled", _actorNumber, topicPartition, offset);
+                    if (Log.IsDebugEnabled)
+                        Log.Debug("#{0} Seeking {1} to {2} after partition SubSource cancelled", _actorNumber,
+                            topicPartition, offset);
                     var topicPartitionOffset = new TopicPartitionOffset(topicPartition, offset);
                     SeekAndEmitSubSources(
-                        formerlyUnknown: ImmutableHashSet<TopicPartition>.Empty, 
+                        formerlyUnknown: ImmutableHashSet<TopicPartition>.Empty,
                         offsets: ImmutableList.Create(topicPartitionOffset).ToImmutableHashSet());
                     break;
                 case ReEmit _:
@@ -354,7 +417,8 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
 
         private void UpdatePendingPartitionsAndEmitSubSources(IImmutableSet<TopicPartition> formerlyUnknownPartitions)
         {
-            _pendingPartitions = _pendingPartitions.Union(formerlyUnknownPartitions.Where(tp => !_partitionsInStartup.Contains(tp)));
+            _pendingPartitions =
+                _pendingPartitions.Union(formerlyUnknownPartitions.Where(tp => !_partitionsInStartup.Contains(tp)));
 
             EmitSubSourcesForPendingPartitions();
         }
@@ -370,7 +434,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
                     _pendingPartitions = _pendingPartitions.Remove(topicPartition);
                     _partitionsInStartup = _partitionsInStartup.Add(topicPartition);
 
-                    var subSourceStage = new SubSourceStreamStage(
+                    var subSourceStage = new SubSourceStage<,,>(
                         topicPartition,
                         ConsumerActor,
                         _subsourceStartedCallback,
@@ -404,7 +468,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
         {
             if (ex is not null and not SubscriptionWithCancelException.NonFailureCancellation)
                 Log.Info(ex, $"{nameof(SubSourceLogic<K, V, TMessage>)} was shutdown due to exception");
-            
+
             SetKeepGoing(true);
 
             // TODO from alpakka: we should wait for subsources to be shutdown and next shutdown main stage
@@ -422,8 +486,9 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
                     CompleteStage();
                 }
             });
-            
-            Materializer.ScheduleOnce(_settings.StopTimeout, () => ConsumerActor.Tell(KafkaConsumerActorMetadata.Internal.Stop.Instance));
+
+            Materializer.ScheduleOnce(_settings.StopTimeout,
+                () => ConsumerActor.Tell(KafkaConsumerActorMetadata.Internal.Stop.Instance));
         }
 
         /// <summary>
@@ -437,13 +502,14 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
             public SubSourcePromiseControl(SourceShape<(
                     TopicPartition,
                     Source<TMessage, NotUsed>)> shape,
-                    Action<Outlet<(TopicPartition, Source<TMessage, NotUsed>)>> completeStageOutlet,
-                    Action<bool> setStageKeepGoing, 
-                    Func<Action, Action> asyncCallbackFactory,
-                    Func<Action<Exception?>, Action<Exception?>> asyncShutdownCallbackFactory,
-                    Action performStop, 
-                    Action<Exception?> performShutdown)
-                : base(shape, completeStageOutlet, setStageKeepGoing, asyncCallbackFactory, asyncShutdownCallbackFactory)
+                Action<Outlet<(TopicPartition, Source<TMessage, NotUsed>)>> completeStageOutlet,
+                Action<bool> setStageKeepGoing,
+                Func<Action, Action> asyncCallbackFactory,
+                Func<Action<Exception?>, Action<Exception?>> asyncShutdownCallbackFactory,
+                Action performStop,
+                Action<Exception?> performShutdown)
+                : base(shape, completeStageOutlet, setStageKeepGoing, asyncCallbackFactory,
+                    asyncShutdownCallbackFactory)
             {
                 _performStop = performStop;
                 _performShutdown = performShutdown;
@@ -455,191 +521,201 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
             /// <inheritdoc />
             public override void PerformShutdown(Exception? ex) => _performShutdown(ex);
         }
+    }
 
-        private class SubSourceStreamStage : GraphStage<SourceShape<TMessage>>
+    /// <summary>
+    /// INTERNAL API
+    /// </summary>
+    /// <remarks>
+    /// A <see cref="SubSourceStage{K,V,TMessage}"/> is created per partition in <see cref="SubSourceLogic{K,V,TMessage}"/>
+    /// </remarks>
+    internal sealed class SubSourceStage<K, V, TMessage> : GraphStage<SourceShape<TMessage>>
+    {
+        private readonly TopicPartition _topicPartition;
+        private readonly IActorRef _consumerActor;
+        private readonly Action<(TopicPartition, IControl)> _subSourceStartedCallback;
+        private readonly Action<(TopicPartition, ISubSourceCancellationStrategy)> _subSourceCancelledCallback;
+        private readonly IMessageBuilder<K, V, TMessage> _messageBuilder;
+        private readonly int _actorNumber;
+        private readonly Decider _decider;
+
+        public Outlet<TMessage> Out { get; }
+        public override SourceShape<TMessage> Shape { get; }
+
+        public SubSourceStage(TopicPartition topicPartition, IActorRef consumerActor,
+            Action<(TopicPartition, IControl)> subSourceStartedCallback,
+            Action<(TopicPartition, ISubSourceCancellationStrategy)> subSourceCancelledCallback,
+            IMessageBuilder<K, V, TMessage> messageBuilder,
+            Decider decider,
+            int actorNumber)
         {
-            private readonly TopicPartition _topicPartition;
-            private readonly IActorRef _consumerActor;
-            private readonly Action<(TopicPartition, IControl)> _subSourceStartedCallback;
-            private readonly Action<(TopicPartition, ISubSourceCancellationStrategy)> _subSourceCancelledCallback;
-            private readonly IMessageBuilder<K, V, TMessage> _messageBuilder;
+            _topicPartition = topicPartition;
+            _consumerActor = consumerActor;
+            _subSourceStartedCallback = subSourceStartedCallback;
+            _subSourceCancelledCallback = subSourceCancelledCallback;
+            _messageBuilder = messageBuilder;
+            _decider = decider;
+            _actorNumber = actorNumber;
+
+            Out = new Outlet<TMessage>("out");
+            Shape = new SourceShape<TMessage>(Out);
+        }
+
+        protected override GraphStageLogic CreateLogic(Attributes inheritedAttributes)
+        {
+            return new SubSourceStageLogic<,,>(Shape, _topicPartition, _consumerActor, _actorNumber, _messageBuilder,
+                _decider,
+                _subSourceStartedCallback, _subSourceCancelledCallback);
+        }
+    }
+
+    internal abstract class SubSourceStageLogic<K, V, TMessage> : GraphStageLogic
+    {
+        private readonly SourceShape<TMessage> _shape;
+        private readonly TopicPartition _topicPartition;
+        private readonly IActorRef _consumerActor;
+        private readonly int _actorNumber;
+        private readonly IMessageBuilder<K, V, TMessage> _messageBuilder;
+        private readonly Action<(TopicPartition, IControl)> _subSourceStartedCallback;
+        private readonly KafkaConsumerActorMetadata.Internal.RequestMessages _requestMessages;
+        private bool _requested = false;
+        private StageActor _subSourceActor = null!;
+        private readonly Decider _decider;
+        private readonly ConcurrentQueue<ConsumeResult<K, V>> _buffer = new();
+
+        public PromiseControl<TMessage> Control { get; }
+
+        public SubSourceStageLogic(SourceShape<TMessage> shape, TopicPartition topicPartition,
+            IActorRef consumerActor,
+            int actorNumber, IMessageBuilder<K, V, TMessage> messageBuilder, Decider decider,
+            Action<(TopicPartition, IControl)> subSourceStartedCallback,
+            Action<(TopicPartition, ISubSourceCancellationStrategy)> subSourceCancelledCallback)
+            : base(shape)
+        {
+            _shape = shape;
+            _topicPartition = topicPartition;
+            _consumerActor = consumerActor;
+            _actorNumber = actorNumber;
+            _messageBuilder = messageBuilder;
+            _decider = decider;
+            _subSourceStartedCallback = subSourceStartedCallback;
+            _requestMessages =
+                new KafkaConsumerActorMetadata.Internal.RequestMessages(0, ImmutableHashSet.Create(topicPartition));
+
+            Control = new SubSourceStreamPromiseControl(
+                shape: shape,
+                completeStageOutlet: Complete,
+                setStageKeepGoing: SetKeepGoing,
+                asyncCallbackFactory: GetAsyncCallback,
+                asyncShutdownCallbackFactory: GetAsyncCallback,
+                debugLog: (message, args) => Log.Debug(message, args),
+                actorNumber: actorNumber,
+                topicPartition: topicPartition,
+                completeStage: ex => CompleteStage());
+
+            SetHandler(shape.Outlet, onPull: Pump, onDownstreamFinish: ex =>
+            {
+                subSourceCancelledCallback((
+                    topicPartition,
+                    _buffer.TryPeek(out var next) ? new SeekToOffsetAndReEmit(next.Offset) : ReEmit.Instance));
+                //CompleteStage();
+            });
+        }
+
+        public override void PreStart()
+        {
+            base.PreStart();
+            Log.Debug("{0} Starting SubSource for partition {1}", _actorNumber, _topicPartition);
+
+            _subSourceActor = GetStageActor(MessageHandling());
+            _subSourceActor.Watch(_consumerActor);
+
+            _subSourceStartedCallback((_topicPartition, Control));
+            // consumerActor.tell(RegisterSubStage(requestMessages.tps), subSourceActor.ref) // JVM
+        }
+
+        private StageActorRef.Receive MessageHandling() => args =>
+        {
+            var (actor, message) = args;
+
+            switch (message)
+            {
+                case KafkaConsumerActorMetadata.Internal.Messages<K, V> messages:
+                    _requested = false;
+                    foreach (var consumerMessage in messages.MessagesList)
+                        _buffer.Enqueue(consumerMessage);
+
+                    Pump();
+                    break;
+                case Status.Failure failure:
+                    FailStage(failure.Cause);
+                    break;
+                case Terminated terminated when terminated.ActorRef.Equals(_consumerActor):
+                    FailStage(new ConsumerFailed());
+                    break;
+            }
+        };
+
+        public override void PostStop()
+        {
+            Control.OnShutdown();
+
+            base.PostStop();
+        }
+
+        private void Pump()
+        {
+            while (true)
+            {
+                if (IsAvailable(_shape.Outlet))
+                {
+                    if (_buffer.TryDequeue(out var message))
+                    {
+                        Push(_shape.Outlet, _messageBuilder.CreateMessage(message));
+                        continue;
+                    }
+
+                    if (!_requested)
+                    {
+                        _requested = true;
+                        _consumerActor.Tell(_requestMessages, _subSourceActor.Ref);
+                    }
+                }
+
+                break;
+            }
+        }
+
+        private class SubSourceStreamPromiseControl : PromiseControl<TMessage>
+        {
+            private readonly Action<string, object[]> _debugLog;
             private readonly int _actorNumber;
-            private readonly Decider _decider;
+            private readonly TopicPartition _topicPartition;
+            private readonly Action<Exception?> _completeStage;
 
-            public Outlet<TMessage> Out { get; }
-            public override SourceShape<TMessage> Shape { get; }
-
-            public SubSourceStreamStage(TopicPartition topicPartition, IActorRef consumerActor,
-                                  Action<(TopicPartition, IControl)> subSourceStartedCallback,
-                                  Action<(TopicPartition, ISubSourceCancellationStrategy)> subSourceCancelledCallback,
-                                  IMessageBuilder<K, V, TMessage> messageBuilder,
-                                  Decider decider,
-                                  int actorNumber)
+            public SubSourceStreamPromiseControl(
+                SourceShape<TMessage> shape,
+                Action<Outlet<TMessage>> completeStageOutlet,
+                Action<bool> setStageKeepGoing,
+                Func<Action, Action> asyncCallbackFactory,
+                Func<Action<Exception?>, Action<Exception?>> asyncShutdownCallbackFactory,
+                Action<string, object[]> debugLog,
+                int actorNumber,
+                TopicPartition topicPartition,
+                Action<Exception?> completeStage)
+                : base(shape, completeStageOutlet, setStageKeepGoing, asyncCallbackFactory,
+                    asyncShutdownCallbackFactory)
             {
-                _topicPartition = topicPartition;
-                _consumerActor = consumerActor;
-                _subSourceStartedCallback = subSourceStartedCallback;
-                _subSourceCancelledCallback = subSourceCancelledCallback;
-                _messageBuilder = messageBuilder;
-                _decider = decider;
+                _debugLog = debugLog;
                 _actorNumber = actorNumber;
-
-                Out = new Outlet<TMessage>("out");
-                Shape = new SourceShape<TMessage>(Out);
+                _topicPartition = topicPartition;
+                _completeStage = completeStage;
             }
 
-            protected override GraphStageLogic CreateLogic(Attributes inheritedAttributes)
+            public override void PerformShutdown(Exception? ex)
             {
-                return new SubSourceStreamStageLogic(Shape, _topicPartition, _consumerActor, _actorNumber, _messageBuilder, _decider,
-                                               _subSourceStartedCallback, _subSourceCancelledCallback);
-            }
-
-            private class SubSourceStreamStageLogic : GraphStageLogic
-            {
-                private readonly SourceShape<TMessage> _shape;
-                private readonly TopicPartition _topicPartition;
-                private readonly IActorRef _consumerActor;
-                private readonly int _actorNumber;
-                private readonly IMessageBuilder<K, V, TMessage> _messageBuilder;
-                private readonly Action<(TopicPartition, IControl)> _subSourceStartedCallback;
-                private readonly KafkaConsumerActorMetadata.Internal.RequestMessages _requestMessages;
-                private bool _requested = false;
-                private StageActor _subSourceActor = null!;
-                private readonly Decider _decider;
-                private readonly ConcurrentQueue<ConsumeResult<K, V>> _buffer = new ConcurrentQueue<ConsumeResult<K, V>>();
-
-                public PromiseControl<TMessage> Control { get; }
-
-                public SubSourceStreamStageLogic(SourceShape<TMessage> shape, TopicPartition topicPartition, IActorRef consumerActor,
-                                           int actorNumber, IMessageBuilder<K, V, TMessage> messageBuilder, Decider decider,
-                                           Action<(TopicPartition, IControl)> subSourceStartedCallback,
-                                           Action<(TopicPartition, ISubSourceCancellationStrategy)> subSourceCancelledCallback)
-                    : base(shape)
-                {
-                    _shape = shape;
-                    _topicPartition = topicPartition;
-                    _consumerActor = consumerActor;
-                    _actorNumber = actorNumber;
-                    _messageBuilder = messageBuilder;
-                    _decider = decider;
-                    _subSourceStartedCallback = subSourceStartedCallback;
-                    _requestMessages = new KafkaConsumerActorMetadata.Internal.RequestMessages(0, ImmutableHashSet.Create(topicPartition));
-
-                    Control = new SubSourceStreamPromiseControl(
-                        shape: shape,
-                        completeStageOutlet: Complete,
-                        setStageKeepGoing: SetKeepGoing,
-                        asyncCallbackFactory: GetAsyncCallback,
-                        asyncShutdownCallbackFactory: GetAsyncCallback,
-                        debugLog: (message, args) => Log.Debug(message, args),
-                        actorNumber: actorNumber,
-                        topicPartition: topicPartition,
-                        completeStage: ex => CompleteStage());
-
-                    SetHandler(shape.Outlet, onPull: Pump, onDownstreamFinish: ex =>
-                    {
-                        subSourceCancelledCallback((
-                            topicPartition, 
-                            _buffer.TryPeek(out var next) ? new SeekToOffsetAndReEmit(next.Offset) : ReEmit.Instance));
-                        //CompleteStage();
-                    });
-                }
-
-                public override void PreStart()
-                {
-                    base.PreStart();
-                    Log.Debug("{0} Starting SubSource for partition {1}", _actorNumber, _topicPartition);
-
-                    _subSourceActor = GetStageActor(MessageHandling());
-                    _subSourceActor.Watch(_consumerActor);
-                    
-                    _subSourceStartedCallback((_topicPartition, Control));
-                    // consumerActor.tell(RegisterSubStage(requestMessages.tps), subSourceActor.ref) // JVM
-                }
-
-                private StageActorRef.Receive MessageHandling() => args =>
-                {
-                    var (actor, message) = args;
-
-                    switch (message)
-                    {
-                        case KafkaConsumerActorMetadata.Internal.Messages<K, V> messages:
-                            _requested = false;
-                            foreach (var consumerMessage in messages.MessagesList)
-                                _buffer.Enqueue(consumerMessage);
-
-                            Pump();
-                            break;
-                        case Status.Failure failure:
-                            FailStage(failure.Cause);
-                            break;
-                        case Terminated terminated when terminated.ActorRef.Equals(_consumerActor):
-                            FailStage(new ConsumerFailed());
-                            break;
-                    }
-                };
-
-                public override void PostStop()
-                {
-                    Control.OnShutdown();
-
-                    base.PostStop();
-                }
-
-                private void Pump()
-                {
-                    while (true)
-                    {
-                        if (IsAvailable(_shape.Outlet))
-                        {
-                            if (_buffer.TryDequeue(out var message))
-                            {
-                                Push(_shape.Outlet, _messageBuilder.CreateMessage(message));
-                                continue;
-                            }
-                            
-                            if (!_requested)
-                            {
-                                _requested = true;
-                                _consumerActor.Tell(_requestMessages, _subSourceActor.Ref);
-                            }
-                        }
-
-                        break;
-                    }
-                }
-
-                private class SubSourceStreamPromiseControl : PromiseControl<TMessage>
-                {
-                    private readonly Action<string, object[]> _debugLog;
-                    private readonly int _actorNumber;
-                    private readonly TopicPartition _topicPartition;
-                    private readonly Action<Exception?> _completeStage;
-
-                    public SubSourceStreamPromiseControl(
-                        SourceShape<TMessage> shape,
-                        Action<Outlet<TMessage>> completeStageOutlet,
-                        Action<bool> setStageKeepGoing,
-                        Func<Action, Action> asyncCallbackFactory,
-                        Func<Action<Exception?>, Action<Exception?>> asyncShutdownCallbackFactory,
-                        Action<string, object[]> debugLog,
-                        int actorNumber,
-                        TopicPartition topicPartition,
-                        Action<Exception?> completeStage)
-                        : base(shape, completeStageOutlet, setStageKeepGoing, asyncCallbackFactory, asyncShutdownCallbackFactory)
-                    {
-                        _debugLog = debugLog;
-                        _actorNumber = actorNumber;
-                        _topicPartition = topicPartition;
-                        _completeStage = completeStage;
-                    }
-
-                    public override void PerformShutdown(Exception? ex)
-                    {
-                        _debugLog("#{0} Completing SubSource for partition {1}", [_actorNumber, _topicPartition]);
-                        _completeStage(ex);
-                    }
-                }
+                _debugLog("#{0} Completing SubSource for partition {1}", [_actorNumber, _topicPartition]);
+                _completeStage(ex);
             }
         }
     }

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/SubSourceLogic.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/SubSourceLogic.cs
@@ -98,6 +98,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
         private readonly ConsumerSettings<K, V> _settings;
         private readonly IAutoSubscription _subscription;
         private readonly IMessageBuilder<K, V, TMessage> _messageBuilder;
+        private readonly ISubSourceStageLogicFactory<K, V, TMessage> _subSourceStageLogicFactory;
 
         private readonly Option<Func<IImmutableSet<TopicPartition>, Task<IImmutableSet<TopicPartitionOffset>>>>
             _getOffsetsOnAssign;
@@ -139,22 +140,22 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
         public IActorRef ConsumerActor { get; private set; } = null!;
 
         public PromiseControl<(TopicPartition, Source<TMessage, NotUsed>)> Control { get; }
-
-        /// <summary>
-        /// SubSourceLogic
-        /// </summary>
+        
         public SubSourceLogic(SourceShape<(TopicPartition, Source<TMessage, NotUsed>)> shape,
             ConsumerSettings<K, V> settings,
             IAutoSubscription subscription,
             Func<SubSourceLogic<K, V, TMessage>, IMessageBuilder<K, V, TMessage>> messageBuilderFactory,
             Option<Func<IImmutableSet<TopicPartition>, Task<IImmutableSet<TopicPartitionOffset>>>> getOffsetsOnAssign,
-            Action<IImmutableSet<TopicPartition>> onRevoke, Attributes attributes)
+            Action<IImmutableSet<TopicPartition>> onRevoke,
+            ISubSourceStageLogicFactory<K, V, TMessage> subSourceStageLogicFactory,
+            Attributes attributes)
             : base(shape)
         {
             _shape = shape;
             _settings = settings;
             _subscription = subscription;
             _messageBuilder = messageBuilderFactory(this);
+            _subSourceStageLogicFactory = subSourceStageLogicFactory;
             _getOffsetsOnAssign = getOffsetsOnAssign;
             _onRevoke = onRevoke;
 
@@ -222,7 +223,8 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
         public override void PreStart()
         {
             base.PreStart();
-
+            Log.Info("Starting");
+            
             SourceActor = GetStageActor(args =>
             {
                 switch (args.Item2)
@@ -233,6 +235,9 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
 
                     case Terminated terminated when terminated.ActorRef.Equals(ConsumerActor):
                         FailStage(new ConsumerFailed());
+                        break;
+                    case not null:
+                        Log.Warning("Ignoring message [{0}]", args.Item2);
                         break;
                 }
             });
@@ -330,42 +335,31 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
         private void SeekAndEmitSubSources(IImmutableSet<TopicPartition> formerlyUnknown,
             IImmutableSet<TopicPartitionOffset> offsets)
         {
-            ConsumerActor.Ask(new KafkaConsumerActorMetadata.Internal.Seek(offsets), TimeSpan.FromSeconds(10))
-                .ContinueWith(t =>
-                {
-                    if (t.IsCanceled)
-                    {
-                        _stageFailCallback(new ConsumerFailed(
-                            $"{_actorNumber} Consumer failed during seek, task cancelled. Partitions: {offsets.JoinToString(", ")}"));
-                    }
-                    else if (t.IsFaulted)
-                    {
-                        if (t.Exception == null)
-                            throw new Exception(
-                                $"{_actorNumber} Consumer failed during seek, task faulted with null cause. Partitions: {offsets.JoinToString(", ")}");
+            _ = AskToSeekOffsets();
+            return;
 
-                        if (t.Exception.Flatten().InnerExceptions.OfType<AskTimeoutException>().Any())
-                        {
-                            _stageFailCallback(new ConsumerFailed(
-                                $"{_actorNumber} Consumer failed during seek, Ask timed out. Partitions: {offsets.JoinToString(", ")}"));
-                        }
-                        else
-                        {
-                            ExceptionDispatchInfo.Capture(t.Exception).Throw();
-                        }
-                    }
-                    else
-                    {
-                        _updatePendingPartitionsAndEmitSubSourcesCallback(formerlyUnknown);
-                    }
-                }, TaskContinuationOptions.ExecuteSynchronously);
+            async Task AskToSeekOffsets()
+            {
+                try
+                {
+                    await ConsumerActor.Ask(new KafkaConsumerActorMetadata.Internal.Seek(offsets),
+                        TimeSpan.FromSeconds(10));
+                    _updatePendingPartitionsAndEmitSubSourcesCallback(formerlyUnknown);
+                }
+                catch (Exception)
+                {
+                    // only exceptions that can be thrown here are related to TCS cancellation / timeout
+                    _stageFailCallback(new ConsumerFailed(
+                        $"{_actorNumber} Consumer failed during seek, Ask timed out. Partitions: {offsets.JoinToString(", ")}"));
+                }
+            }
         }
 
         private void HandlePartitionsRevoked(IImmutableSet<TopicPartitionOffset> revoked)
         {
             _partitionsToRevoke = _partitionsToRevoke.Union(revoked.Select(r => r.TopicPartition));
 
-            ScheduleOnce(SubSourceLogic.CloseRevokedPartitions.Instance, _settings.WaitClosePartition);
+            ScheduleOnce(CloseRevokedPartitions.Instance, _settings.WaitClosePartition);
         }
 
         private void HandleSubsourceCancelled((TopicPartition, ISubSourceCancellationStrategy) obj)
@@ -389,7 +383,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
                         formerlyUnknown: ImmutableHashSet<TopicPartition>.Empty,
                         offsets: ImmutableList.Create(topicPartitionOffset).ToImmutableHashSet());
                     break;
-                case ReEmit _:
+                case ReEmit:
                     // re-add this partition to pending partitions so it can be re-emitted
                     _pendingPartitions = _pendingPartitions.Add(topicPartition);
                     EmitSubSourcesForPendingPartitions();
@@ -434,7 +428,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
                     _pendingPartitions = _pendingPartitions.Remove(topicPartition);
                     _partitionsInStartup = _partitionsInStartup.Add(topicPartition);
 
-                    var subSourceStage = new SubSourceStage<,,>(
+                    var subSourceStage = new SubSourceStage<K,V,TMessage>(
                         topicPartition,
                         ConsumerActor,
                         _subsourceStartedCallback,
@@ -533,9 +527,10 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
     {
         private readonly TopicPartition _topicPartition;
         private readonly IActorRef _consumerActor;
-        private readonly Action<(TopicPartition, IControl)> _subSourceStartedCallback;
+        private readonly Action<SubSourceStageLogicControl> _subSourceStartedCallback;
         private readonly Action<(TopicPartition, ISubSourceCancellationStrategy)> _subSourceCancelledCallback;
         private readonly IMessageBuilder<K, V, TMessage> _messageBuilder;
+        private readonly ISubSourceStageLogicFactory<K, V, TMessage> _subSourceStageLogicFactory;
         private readonly int _actorNumber;
         private readonly Decider _decider;
 
@@ -543,11 +538,11 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
         public override SourceShape<TMessage> Shape { get; }
 
         public SubSourceStage(TopicPartition topicPartition, IActorRef consumerActor,
-            Action<(TopicPartition, IControl)> subSourceStartedCallback,
+            Action<SubSourceStageLogicControl> subSourceStartedCallback,
             Action<(TopicPartition, ISubSourceCancellationStrategy)> subSourceCancelledCallback,
             IMessageBuilder<K, V, TMessage> messageBuilder,
             Decider decider,
-            int actorNumber)
+            int actorNumber, ISubSourceStageLogicFactory<K, V, TMessage> subSourceStageLogicFactory)
         {
             _topicPartition = topicPartition;
             _consumerActor = consumerActor;
@@ -556,6 +551,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
             _messageBuilder = messageBuilder;
             _decider = decider;
             _actorNumber = actorNumber;
+            _subSourceStageLogicFactory = subSourceStageLogicFactory;
 
             Out = new Outlet<TMessage>("out");
             Shape = new SourceShape<TMessage>(Out);
@@ -563,9 +559,8 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
 
         protected override GraphStageLogic CreateLogic(Attributes inheritedAttributes)
         {
-            return new SubSourceStageLogic<,,>(Shape, _topicPartition, _consumerActor, _actorNumber, _messageBuilder,
-                _decider,
-                _subSourceStartedCallback, _subSourceCancelledCallback);
+            return _subSourceStageLogicFactory.Create(Shape, _topicPartition, _consumerActor, 
+                _subSourceStartedCallback, _subSourceCancelledCallback, _actorNumber);
         }
     }
 

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/SubSourceLogic.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/SubSourceLogic.cs
@@ -1,9 +1,7 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Streams.Dsl;
@@ -128,8 +126,8 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
         /// </summary>
         private IImmutableSet<TopicPartition> _partitionsInStartup = ImmutableHashSet<TopicPartition>.Empty;
 
-        private IImmutableDictionary<TopicPartition, IControl> _subSources =
-            ImmutableDictionary<TopicPartition, IControl>.Empty;
+        private IImmutableDictionary<TopicPartition, SubSourceStageLogicControl> _subSources =
+            ImmutableDictionary<TopicPartition,SubSourceStageLogicControl>.Empty;
 
         /// <summary>
         /// Kafka has signalled these partitions are revoked, but some may be re-assigned just after revoking.
@@ -210,12 +208,54 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
             }
         }
 
+        private class FlushMessagesOfRevokedPartitionsHandler : IPartitionEventHandler
+        {
+            private IImmutableSet<TopicPartitionOffset> _lastRevoked = ImmutableHashSet<TopicPartitionOffset>.Empty;
+            private readonly SubSourceLogic<K, V, TMessage> _stageLogic;
+
+            public FlushMessagesOfRevokedPartitionsHandler(SubSourceLogic<K, V, TMessage> stageLogic)
+            {
+                _stageLogic = stageLogic;
+            }
+
+            public void OnRevoke(IImmutableSet<TopicPartitionOffset> revokedTopicPartitions,
+                IRestrictedConsumer consumer)
+            {
+                _lastRevoked = revokedTopicPartitions;
+            }
+
+            public void OnLost(IImmutableSet<TopicPartitionOffset> revokedTopicPartitions, IRestrictedConsumer consumer)
+            {
+                foreach (var tp in revokedTopicPartitions)
+                {
+                    if (_stageLogic._subSources.TryGetValue(tp.TopicPartition, out var control))
+                        control.FilterRevokedPartitionsCb(revokedTopicPartitions);
+                }
+            }
+
+            public void OnAssign(IImmutableSet<TopicPartition> assignedTopicPartitions, IRestrictedConsumer consumer)
+            {
+                // remove all of our previous revoked partitions that are not in the new assignment
+                var safeToRevoke = _lastRevoked
+                    .Where(c => !assignedTopicPartitions.Contains(c.TopicPartition))
+                    .ToImmutableHashSet();
+
+                foreach (var tp in safeToRevoke)
+                {
+                    if(_stageLogic._subSources.TryGetValue(tp.TopicPartition, out var control))
+                        control.FilterRevokedPartitionsCb(safeToRevoke);
+                }
+            }
+
+            public void OnStop(IImmutableSet<TopicPartition> topicPartitions, IRestrictedConsumer consumer){}
+        }
+
         /// <summary>
         /// Opportunity for subclasses to add their logic to the partition assignment callbacks.
         /// </summary>
         protected virtual IPartitionEventHandler AddToPartitionAssignmentHandler(IPartitionEventHandler handler)
         {
-            return handler;
+            return new PartitionEventHandlers.Chain(handler, new FlushMessagesOfRevokedPartitionsHandler(this));
         }
 
         public override void PreStart()
@@ -268,10 +308,11 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
 
         protected override void OnTimer(object timerKey)
         {
-            if (timerKey is SubSourceLogic.CloseRevokedPartitions)
+            if (timerKey is CloseRevokedPartitions)
             {
-                Log.Debug("#{0} Closing SubSources for revoked partitions: {1}", _actorNumber,
-                    _partitionsToRevoke.JoinToString(", "));
+                if(Log.IsDebugEnabled)
+                    Log.Debug("#{0} Closing SubSources for revoked partitions: {1}", _actorNumber,
+                        _partitionsToRevoke.JoinToString(", "));
 
                 _onRevoke(_partitionsToRevoke);
                 _pendingPartitions = _pendingPartitions.Except(_partitionsToRevoke);
@@ -279,10 +320,14 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
                 _partitionsToRevoke.ForEach(tp =>
                 {
                     if (_subSources.TryGetValue(tp, out var source))
-                        source.Shutdown(PartitionWasRevoked.Instance);
+                        source.ControlAndStageActor.Control.Shutdown(PartitionWasRevoked.Instance);
                 });
                 _subSources = _subSources.RemoveRange(_partitionsToRevoke);
                 _partitionsToRevoke = ImmutableHashSet<TopicPartition>.Empty;
+            }
+            else
+            {
+                Log.Warning("Unexpected timer [{0}]", timerKey);
             }
         }
 
@@ -403,7 +448,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
             }
             else
             {
-                _subSources = _subSources.SetItem(tp, control);
+                _subSources = _subSources.SetItem(tp, sssLogicControl);
                 _partitionsInStartup = _partitionsInStartup.Remove(tp);
             }
         }
@@ -450,7 +495,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
         {
             SetKeepGoing(true);
 
-            _subSources.Values.ForEach(control => control.Stop());
+            _subSources.Values.Select(c => c.ControlAndStageActor.Control).ForEach(control => control.Stop());
 
             Complete(_shape.Outlet);
 
@@ -465,7 +510,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
             SetKeepGoing(true);
 
             // TODO from alpakka: we should wait for subsources to be shutdown and next shutdown main stage
-            _subSources.Values.ForEach(control => control.Shutdown(ex));
+            _subSources.Values.Select(c => c.ControlAndStageActor.Control).ForEach(control => control.Shutdown(ex));
 
             if (!IsClosed(_shape.Outlet))
                 Complete(_shape.Outlet);
@@ -478,11 +523,17 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
                     Control.OnShutdown();
                     CompleteStage();
                 }
+                else
+                {
+                    Log.Warning("Ignoring message [{0}]", message);
+                }
             });
 
             Materializer.ScheduleOnce(_settings.StopTimeout,
                 () => ConsumerActor.Tell(KafkaConsumerActorMetadata.Internal.Stop.Instance));
         }
+        
+        
 
         /// <summary>
         /// Overrides some method of base <see cref="PromiseControl{TSourceOut}"/>

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/SubSourceLogic.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/SubSourceLogic.cs
@@ -98,7 +98,6 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
         private readonly SourceShape<(TopicPartition, Source<TMessage, NotUsed>)> _shape;
         private readonly ConsumerSettings<K, V> _settings;
         private readonly IAutoSubscription _subscription;
-        private readonly IMessageBuilder<K, V, TMessage> _messageBuilder;
         private readonly ISubSourceStageLogicFactory<K, V, TMessage> _subSourceStageLogicFactory;
 
         private readonly Option<Func<IImmutableSet<TopicPartition>, Task<IImmutableSet<TopicPartitionOffset>>>>
@@ -145,7 +144,6 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
         public SubSourceLogic(SourceShape<(TopicPartition, Source<TMessage, NotUsed>)> shape,
             ConsumerSettings<K, V> settings,
             IAutoSubscription subscription,
-            Func<SubSourceLogic<K, V, TMessage>, IMessageBuilder<K, V, TMessage>> messageBuilderFactory,
             Option<Func<IImmutableSet<TopicPartition>, Task<IImmutableSet<TopicPartitionOffset>>>> getOffsetsOnAssign,
             Action<IImmutableSet<TopicPartition>> onRevoke,
             ISubSourceStageLogicFactory<K, V, TMessage> subSourceStageLogicFactory,
@@ -155,7 +153,6 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
             _shape = shape;
             _settings = settings;
             _subscription = subscription;
-            _messageBuilder = messageBuilderFactory(this);
             _subSourceStageLogicFactory = subSourceStageLogicFactory;
             _getOffsetsOnAssign = getOffsetsOnAssign;
             _onRevoke = onRevoke;
@@ -435,7 +432,6 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
                         ConsumerActor,
                         _subsourceStartedCallback,
                         _subsourceCancelledCallback,
-                        _messageBuilder,
                         _decider,
                         _actorNumber,
                         _subSourceStageLogicFactory);
@@ -532,7 +528,6 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
         private readonly IActorRef _consumerActor;
         private readonly Action<SubSourceStageLogicControl> _subSourceStartedCallback;
         private readonly Action<(TopicPartition, ISubSourceCancellationStrategy)> _subSourceCancelledCallback;
-        private readonly IMessageBuilder<K, V, TMessage> _messageBuilder;
         private readonly ISubSourceStageLogicFactory<K, V, TMessage> _subSourceStageLogicFactory;
         private readonly int _actorNumber;
         private readonly Decider _decider;
@@ -543,7 +538,6 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
         public SubSourceStage(TopicPartition topicPartition, IActorRef consumerActor,
             Action<SubSourceStageLogicControl> subSourceStartedCallback,
             Action<(TopicPartition, ISubSourceCancellationStrategy)> subSourceCancelledCallback,
-            IMessageBuilder<K, V, TMessage> messageBuilder,
             Decider decider,
             int actorNumber, ISubSourceStageLogicFactory<K, V, TMessage> subSourceStageLogicFactory)
         {
@@ -551,7 +545,6 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
             _consumerActor = consumerActor;
             _subSourceStartedCallback = subSourceStartedCallback;
             _subSourceCancelledCallback = subSourceCancelledCallback;
-            _messageBuilder = messageBuilder;
             _decider = decider;
             _actorNumber = actorNumber;
             _subSourceStageLogicFactory = subSourceStageLogicFactory;

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/SubSourceLogic.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/SubSourceLogic.cs
@@ -657,7 +657,8 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
                 FilterRevokedPartitionAsyncCallback);
 
             _subSourceStartedCallback(started);
-            // consumerActor.tell(RegisterSubStage(requestMessages.tps), subSourceActor.ref) // JVM
+            _consumerActor.Tell(new KafkaConsumerActorMetadata.Internal.RegisterSubStage(_requestMessages.Topics),
+                _subSourceActor.Ref);
         }
 
         private StageActorRef.Receive MessageHandling() => args =>

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/SubSourceLogic.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/SubSourceLogic.cs
@@ -208,15 +208,10 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
             }
         }
 
-        private class FlushMessagesOfRevokedPartitionsHandler : IPartitionEventHandler
+        private class FlushMessagesOfRevokedPartitionsHandler(SubSourceLogic<K, V, TMessage> stageLogic)
+            : IPartitionEventHandler
         {
             private IImmutableSet<TopicPartitionOffset> _lastRevoked = ImmutableHashSet<TopicPartitionOffset>.Empty;
-            private readonly SubSourceLogic<K, V, TMessage> _stageLogic;
-
-            public FlushMessagesOfRevokedPartitionsHandler(SubSourceLogic<K, V, TMessage> stageLogic)
-            {
-                _stageLogic = stageLogic;
-            }
 
             public void OnRevoke(IImmutableSet<TopicPartitionOffset> revokedTopicPartitions,
                 IRestrictedConsumer consumer)
@@ -228,7 +223,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
             {
                 foreach (var tp in revokedTopicPartitions)
                 {
-                    if (_stageLogic._subSources.TryGetValue(tp.TopicPartition, out var control))
+                    if (stageLogic._subSources.TryGetValue(tp.TopicPartition, out var control))
                         control.FilterRevokedPartitionsCb(revokedTopicPartitions);
                 }
             }
@@ -242,7 +237,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
 
                 foreach (var tp in safeToRevoke)
                 {
-                    if(_stageLogic._subSources.TryGetValue(tp.TopicPartition, out var control))
+                    if(stageLogic._subSources.TryGetValue(tp.TopicPartition, out var control))
                         control.FilterRevokedPartitionsCb(safeToRevoke);
                 }
             }
@@ -250,10 +245,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
             public void OnStop(IImmutableSet<TopicPartition> topicPartitions, IRestrictedConsumer consumer){}
         }
 
-        /// <summary>
-        /// Opportunity for subclasses to add their logic to the partition assignment callbacks.
-        /// </summary>
-        protected virtual IPartitionEventHandler AddToPartitionAssignmentHandler(IPartitionEventHandler handler)
+        private IPartitionEventHandler AddToPartitionAssignmentHandler(IPartitionEventHandler handler)
         {
             return new PartitionEventHandlers.Chain(handler, new FlushMessagesOfRevokedPartitionsHandler(this));
         }

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/SubSourceLogic.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/SubSourceLogic.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Runtime.ExceptionServices;
@@ -110,7 +111,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
         private readonly Action<IImmutableSet<TopicPartition>> _updatePendingPartitionsAndEmitSubSourcesCallback;
         private readonly Action<IImmutableSet<TopicPartitionOffset>> _partitionRevokedCallback;
         private readonly Action<(TopicPartition, ISubSourceCancellationStrategy)> _subsourceCancelledCallback;
-        private readonly Action<(TopicPartition, IControl)> _subsourceStartedCallback;
+        private readonly Action<SubSourceStageLogicControl> _subsourceStartedCallback;
 
         private readonly Action<(IImmutableSet<TopicPartition>, IImmutableSet<TopicPartitionOffset>)>
             _offsetsFromExternalResponseCb;
@@ -172,7 +173,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
             _stageFailCallback = GetAsyncCallback<ConsumerFailed>(FailStage);
             _subsourceCancelledCallback =
                 GetAsyncCallback<(TopicPartition, ISubSourceCancellationStrategy)>(HandleSubsourceCancelled);
-            _subsourceStartedCallback = GetAsyncCallback<(TopicPartition, IControl)>(HandleSubsourceStarted);
+            _subsourceStartedCallback = GetAsyncCallback<SubSourceStageLogicControl>(HandleSubsourceStarted);
             _offsetsFromExternalResponseCb =
                 GetAsyncCallback<(IImmutableSet<TopicPartition>, IImmutableSet<TopicPartitionOffset>)>(
                     OffsetsFromExternalResponseCallback);
@@ -393,19 +394,20 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
             }
         }
 
-        private void HandleSubsourceStarted((TopicPartition, IControl) obj)
+        private void HandleSubsourceStarted(SubSourceStageLogicControl sssLogicControl)
         {
-            var (topicPartition, control) = obj;
+            var tp = sssLogicControl.TopicPartition;
+            var control = sssLogicControl.ControlAndStageActor.Control;
 
-            if (!_partitionsInStartup.Contains(topicPartition))
+            if (!_partitionsInStartup.Contains(tp))
             {
                 // Partition was revoked while starting up. Kill!
                 control.Shutdown(PartitionWasRevoked.Instance);
             }
             else
             {
-                _subSources = _subSources.SetItem(topicPartition, control);
-                _partitionsInStartup = _partitionsInStartup.Remove(topicPartition);
+                _subSources = _subSources.SetItem(tp, control);
+                _partitionsInStartup = _partitionsInStartup.Remove(tp);
             }
         }
 
@@ -435,7 +437,8 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
                         _subsourceCancelledCallback,
                         _messageBuilder,
                         _decider,
-                        _actorNumber);
+                        _actorNumber,
+                        _subSourceStageLogicFactory);
                     var subsource = Source.FromGraph(subSourceStage);
 
                     Push(_shape.Outlet, (topicPartition, subsource));
@@ -564,6 +567,14 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
         }
     }
 
+    /// <summary>
+    /// INTERNAL API
+    ///
+    /// A <see cref="SubSourceStageLogic{K,V,TMessage}"/> is the <see cref="GraphStageLogic"/>
+    /// of a <see cref="SubSourceStage{K,V,TMessage}"/>.
+    ///
+    /// This emits the actual Kafka messages downstream.
+    /// </summary>
     internal abstract class SubSourceStageLogic<K, V, TMessage> : GraphStageLogic
     {
         private readonly SourceShape<TMessage> _shape;
@@ -571,19 +582,35 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
         private readonly IActorRef _consumerActor;
         private readonly int _actorNumber;
         private readonly IMessageBuilder<K, V, TMessage> _messageBuilder;
-        private readonly Action<(TopicPartition, IControl)> _subSourceStartedCallback;
+        private readonly Action<SubSourceStageLogicControl> _subSourceStartedCallback;
         private readonly KafkaConsumerActorMetadata.Internal.RequestMessages _requestMessages;
         private bool _requested = false;
         private StageActor _subSourceActor = null!;
-        private readonly Decider _decider;
-        private readonly ConcurrentQueue<ConsumeResult<K, V>> _buffer = new();
+        private Queue<ConsumeResult<K, V>> _buffer = new();
+        
+        public Action<IImmutableSet<TopicPartitionOffset>> FilterRevokedPartitionAsyncCallback =>
+            GetAsyncCallback<IImmutableSet<TopicPartitionOffset>>(FilterRevokedPartitions);
+        
+        private void FilterRevokedPartitions(IImmutableSet<TopicPartitionOffset> partitions)
+        {
+            if (partitions.Count > 0)
+            {
+                Log.Debug("Filtering out messages from revoked partitions [{0}]", string.Join(", ", partitions));
+                var tps = partitions.Select(tpo => tpo.TopicPartition).ToImmutableHashSet();
+                
+                // TODO: maybe it makes sense to look at offsets too
+                
+                // Thread-safe - happens inside an async callback
+                _buffer = new Queue<ConsumeResult<K, V>>(_buffer.Where(m => !tps.Contains(m.TopicPartition)));
+            }
+        }
 
         public PromiseControl<TMessage> Control { get; }
 
         public SubSourceStageLogic(SourceShape<TMessage> shape, TopicPartition topicPartition,
             IActorRef consumerActor,
-            int actorNumber, IMessageBuilder<K, V, TMessage> messageBuilder, Decider decider,
-            Action<(TopicPartition, IControl)> subSourceStartedCallback,
+            int actorNumber, IMessageBuilder<K, V, TMessage> messageBuilder, 
+            Action<SubSourceStageLogicControl> subSourceStartedCallback,
             Action<(TopicPartition, ISubSourceCancellationStrategy)> subSourceCancelledCallback)
             : base(shape)
         {
@@ -592,7 +619,6 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
             _consumerActor = consumerActor;
             _actorNumber = actorNumber;
             _messageBuilder = messageBuilder;
-            _decider = decider;
             _subSourceStartedCallback = subSourceStartedCallback;
             _requestMessages =
                 new KafkaConsumerActorMetadata.Internal.RequestMessages(0, ImmutableHashSet.Create(topicPartition));
@@ -611,21 +637,26 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
             SetHandler(shape.Outlet, onPull: Pump, onDownstreamFinish: ex =>
             {
                 subSourceCancelledCallback((
-                    topicPartition,
-                    _buffer.TryPeek(out var next) ? new SeekToOffsetAndReEmit(next.Offset) : ReEmit.Instance));
-                //CompleteStage();
+                    topicPartition, OnDownstreamFinishSubSourceCancellationStrategy));
+                base.InternalOnDownstreamFinish(ex);
             });
         }
+        
+        protected virtual ISubSourceCancellationStrategy OnDownstreamFinishSubSourceCancellationStrategy => _buffer.Count > 0 ? new SeekToOffsetAndReEmit(_buffer.Peek().Offset) : ReEmit.Instance;
 
         public override void PreStart()
         {
             base.PreStart();
-            Log.Debug("{0} Starting SubSource for partition {1}", _actorNumber, _topicPartition);
+            Log.Info("{0} Starting SubSource for partition {1}", _actorNumber, _topicPartition);
 
             _subSourceActor = GetStageActor(MessageHandling());
             _subSourceActor.Watch(_consumerActor);
+            
+            var controlAndActor = new ControlAndStageActor(Control, _subSourceActor.Ref);
+            var started = new SubSourceStageLogicControl(this._topicPartition, controlAndActor,
+                FilterRevokedPartitionAsyncCallback);
 
-            _subSourceStartedCallback((_topicPartition, Control));
+            _subSourceStartedCallback(started);
             // consumerActor.tell(RegisterSubStage(requestMessages.tps), subSourceActor.ref) // JVM
         }
 
@@ -639,7 +670,6 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
                     _requested = false;
                     foreach (var consumerMessage in messages.MessagesList)
                         _buffer.Enqueue(consumerMessage);
-
                     Pump();
                     break;
                 case Status.Failure failure:
@@ -664,8 +694,9 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
             {
                 if (IsAvailable(_shape.Outlet))
                 {
-                    if (_buffer.TryDequeue(out var message))
+                    if (_buffer.Count > 0)
                     {
+                        var message = _buffer.Dequeue();
                         Push(_shape.Outlet, _messageBuilder.CreateMessage(message));
                         continue;
                     }

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/SubSourceLogic.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/SubSourceLogic.cs
@@ -18,42 +18,35 @@ using Akka.Util;
 using Akka.Util.Internal;
 using Confluent.Kafka;
 using Decider = Akka.Streams.Supervision.Decider;
+using static Akka.Streams.Kafka.Stages.Consumers.Abstract.SubSourceLogic;
 
 namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
 {
-    internal interface ISubSourceCancellationStrategy { }
-
-    internal sealed class SeekToOffsetAndReEmit : ISubSourceCancellationStrategy
-    {
-        public SeekToOffsetAndReEmit(long offset)
-        {
-            Offset = offset;
-        }
-
-        public long Offset { get; }
-    }
-
-    internal sealed class ReEmit : ISubSourceCancellationStrategy
-    {
-        public static readonly ISubSourceCancellationStrategy Instance = new ReEmit();
-        private ReEmit() {}
-    }
-
-    internal sealed class DoNothing : ISubSourceCancellationStrategy
-    {
-        public static readonly ISubSourceCancellationStrategy Instance = new DoNothing();
-        private DoNothing() {}
-    }
-
     /// <summary>
     /// INTERNAL API
     /// </summary>
-    internal static class SubSourceLogicHelpers
+    internal static class SubSourceLogic
     {
         public sealed class CloseRevokedPartitions
         {
             public static readonly CloseRevokedPartitions Instance = new();
             private CloseRevokedPartitions(){}
+        }
+        
+        internal interface ISubSourceCancellationStrategy;
+
+        internal sealed record SeekToOffsetAndReEmit(long Offset) : ISubSourceCancellationStrategy;
+
+        internal sealed class ReEmit : ISubSourceCancellationStrategy
+        {
+            public static readonly ISubSourceCancellationStrategy Instance = new ReEmit();
+            private ReEmit() {}
+        }
+
+        internal sealed class DoNothing : ISubSourceCancellationStrategy
+        {
+            public static readonly ISubSourceCancellationStrategy Instance = new DoNothing();
+            private DoNothing() {}
         }
     }
     
@@ -218,7 +211,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
 
         protected override void OnTimer(object timerKey)
         {
-            if (timerKey is SubSourceLogicHelpers.CloseRevokedPartitions)
+            if (timerKey is SubSourceLogic.CloseRevokedPartitions)
             {
                 Log.Debug("#{0} Closing SubSources for revoked partitions: {1}", _actorNumber, _partitionsToRevoke.JoinToString(", "));
 
@@ -310,7 +303,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Abstract
         {
             _partitionsToRevoke = _partitionsToRevoke.Union(revoked.Select(r => r.TopicPartition));
 
-            ScheduleOnce(SubSourceLogicHelpers.CloseRevokedPartitions.Instance, _settings.WaitClosePartition);
+            ScheduleOnce(SubSourceLogic.CloseRevokedPartitions.Instance, _settings.WaitClosePartition);
         }
 
         private void HandleSubsourceCancelled((TopicPartition, ISubSourceCancellationStrategy) obj)

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
@@ -437,6 +437,11 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
             }
             catch (Exception ex)
             {
+                if (ex is KafkaException kafkaException)
+                {
+                    _log.Error(kafkaException, "Received Kafka broker exception: {0}, [{1}]", kafkaException.Message, kafkaException.Error);
+                }
+                
                 // only this sender needs to be notified about the failure
                 SendFailure(ex, Sender);
             }

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
@@ -58,11 +58,11 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
         /// </summary>
         private IImmutableDictionary<IActorRef, KafkaConsumerActorMetadata.Internal.RequestMessages> _requests 
             = ImmutableDictionary<IActorRef, KafkaConsumerActorMetadata.Internal.RequestMessages>.Empty;
-        
+
         /// <summary>
         /// Stores stage actors, requesting for more messages
         /// </summary>
-        private IImmutableSet<IActorRef> _requestors = ImmutableHashSet<IActorRef>.Empty;
+        private ImmutableDictionary<IImmutableSet<TopicPartition>, IActorRef> _stageActorsMap = ImmutableDictionary<IImmutableSet<TopicPartition>, IActorRef>.Empty;
         private ICommitRefreshing<K, V> _commitRefreshing = null!;
         private IConsumer<K, V> _consumer = null!;
         private RestrictedConsumer<K, V> _restrictedConsumer = null!;
@@ -202,18 +202,23 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                     HandleSubscription(subscribe);
                     return true;
                 
+                case KafkaConsumerActorMetadata.Internal.RegisterSubStage subStage:
+                    _stageActorsMap = _stageActorsMap.SetItem(subStage.TopicPartitions, Sender);
+                    return true;
+                
                 case KafkaConsumerActorMetadata.Internal.RequestMessages requestMessages:
                     if(_settings.VerboseLogging)
                         _log.Debug("Messages was requested, RequestId: {0}, Partitions: {1}", requestMessages.RequestId, string.Join(", ", requestMessages.Topics));
                     Context.Watch(Sender);
                     CheckOverlappingRequests("RequestMessages", Sender, requestMessages.Topics);
-                    _requests = _requests.SetItem(Sender, requestMessages);
-                    _requestors = _requestors.Add(Sender);
+                    
+                    if(_stageActorsMap.TryGetValue(requestMessages.Topics, out var sender) && sender == Sender)
+                        _requests = _requests.SetItem(Sender, requestMessages);
                     
                     // When many requestors, e.g. many partitions with committablePartitionedSource the
                     // performance is much by collecting more requests/commits before performing the poll.
                     // That is done by sending a message to self, and thereby collect pending messages in mailbox.
-                    if (_requestors.Count == 1)
+                    if (_stageActorsMap.Count == 1)
                     {
                         Poll();
                     }
@@ -248,7 +253,8 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
 
                 case Terminated terminated:
                     _requests = _requests.Remove(terminated.ActorRef);
-                    _requestors = _requestors.Remove(terminated.ActorRef);
+                    _stageActorsMap = _stageActorsMap.Where(c => !c.Value.Equals(terminated.ActorRef))
+                        .ToImmutableDictionary();
                     return true;
 
                 case Metadata.IRequest req:
@@ -385,7 +391,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                 }
 
                 ScheduleFirstPollTask();
-                
+                _stageActorsMap = _stageActorsMap.SetItem(_consumer.Assignment.ToImmutableSet(), Sender);
             }
             catch (Exception ex)
             {
@@ -661,7 +667,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
             // When many requestors, e.g. many partitions with committablePartitionedSource the
             // performance is much by collecting more requests/commits before performing the poll.
             // That is done by sending a message to self, and thereby collect pending messages in mailbox.
-            if (_requestors.Count == 1)
+            if (_stageActorsMap.Count == 1)
             {
                 Poll();
             }

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
@@ -648,7 +648,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                     $"consumer assignment: [{string.Join(", ", _consumer.Assignment.Select(p => p.ToString()))}]");
 
             //send messages to actors
-            foreach (var (stageActorRef, request) in _requests.ToTuples())
+            foreach (var (stageActorRef, request) in _requests)
             {
                 var messages = new List<ConsumeResult<K, V>>();
                 foreach (var message in rawResult)

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
@@ -26,9 +26,10 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
     internal class KafkaConsumerActor<K, V> : ActorBase, ILogReceive, IWithTimers
     {
         private const string PollTimerKey = "PollTimer";
-        
+
         private readonly IActorRef? _owner;
         private ConsumerSettings<K, V> _settings;
+
         /// <summary>
         /// Stores delegates for external handling of statistics
         /// </summary>
@@ -38,15 +39,16 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
         /// Stores delegates for external handling of partition events
         /// </summary>
         private IPartitionEventHandler _partitionEventHandler;
-        
+
         private readonly TimeSpan _warningDuration;
-        
+
         private readonly Internal.Poll<K, V> _pollMessage;
         private readonly Internal.Poll<K, V> _delayedPollMessage;
 
         private TimeSpan _pollTimeout;
-        
-        private ImmutableDictionary<TopicPartition, TopicPartitionOffset> _seekedOffset = ImmutableDictionary<TopicPartition, TopicPartitionOffset>.Empty;
+
+        private ImmutableDictionary<TopicPartition, TopicPartitionOffset> _seekedOffset =
+            ImmutableDictionary<TopicPartition, TopicPartitionOffset>.Empty;
 
         /// <summary>
         /// Limits the blocking on position in [[RebalanceListenerImpl]]
@@ -56,13 +58,15 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
         /// <summary>
         /// Stores all incoming requests from consuming kafka stages
         /// </summary>
-        private IImmutableDictionary<IActorRef, KafkaConsumerActorMetadata.Internal.RequestMessages> _requests 
+        private IImmutableDictionary<IActorRef, KafkaConsumerActorMetadata.Internal.RequestMessages> _requests
             = ImmutableDictionary<IActorRef, KafkaConsumerActorMetadata.Internal.RequestMessages>.Empty;
 
         /// <summary>
         /// Stores stage actors, requesting for more messages
         /// </summary>
-        private ImmutableDictionary<IImmutableSet<TopicPartition>, IActorRef> _stageActorsMap = ImmutableDictionary<IImmutableSet<TopicPartition>, IActorRef>.Empty;
+        private ImmutableDictionary<IImmutableSet<TopicPartition>, IActorRef> _stageActorsMap =
+            ImmutableDictionary<IImmutableSet<TopicPartition>, IActorRef>.Empty;
+
         private ICommitRefreshing<K, V> _commitRefreshing = null!;
         private IConsumer<K, V> _consumer = null!;
         private RestrictedConsumer<K, V> _restrictedConsumer = null!;
@@ -77,10 +81,13 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
         /// Changed by `onPartitionsRevoked` and `onPartitionsAssigned` callbacks
         /// </summary>
         private AtomicBoolean _rebalanceInProgress = new();
+
         /// <summary>
         /// Keeps commit offsets during rebalances for later commit.
         /// </summary>
-        private IImmutableSet<TopicPartitionOffset> _rebalanceCommitStash = ImmutableHashSet<TopicPartitionOffset>.Empty;
+        private IImmutableSet<TopicPartitionOffset>
+            _rebalanceCommitStash = ImmutableHashSet<TopicPartitionOffset>.Empty;
+
         /// <summary>
         /// Keeps commit senders that need a reply once stashed commits are made.
         /// </summary>
@@ -95,51 +102,53 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
         /// <param name="settings">Consumer settings</param>
         /// <param name="decider"></param>
         /// <param name="statisticsHandler">Optional handler for reporting Confluent SDK statistics as a structured JSON payload.</param>
-        public KafkaConsumerActor(IActorRef? owner, ConsumerSettings<K, V> settings, Decider decider, IStatisticsHandler statisticsHandler)
+        public KafkaConsumerActor(IActorRef? owner, ConsumerSettings<K, V> settings, Decider decider,
+            IStatisticsHandler statisticsHandler)
         {
             _owner = owner;
             _settings = settings;
             _decider = decider;
             _statisticsHandler = statisticsHandler;
             _partitionEventHandler = PartitionEventHandlers.Empty.Instance;
-            
+
             _warningDuration = _settings.PartitionHandlerWarning;
-            
+
             _pollMessage = new Internal.Poll<K, V>(this, periodic: true);
             _delayedPollMessage = new Internal.Poll<K, V>(this, periodic: false);
             _log = Context.GetLogger();
         }
 
         public ITimerScheduler Timers { get; set; } = null!;
-        
+
         #region Rebalance listener
+
         // This is RebalanceListener.OnPartitionAssigned on JVM
         private void PartitionsAssignedHandler(IImmutableSet<TopicPartition> partitions)
         {
-            if(_log.IsDebugEnabled)
+            if (_log.IsDebugEnabled)
                 _log.Debug($"Partitions were assigned: {string.Join(", ", partitions)}");
             _pausedPartitions = partitions.ToImmutableList();
-            
+
             _commitRefreshing.AssignedPositions(partitions, _consumer, _settings.PositionTimeout);
 
             var watch = Stopwatch.StartNew();
             _partitionEventHandler.OnAssign(partitions, _restrictedConsumer);
             watch.Stop();
             CheckDuration(watch, "onAssign");
-            
+
             _rebalanceInProgress.GetAndSet(false);
         }
 
         // This is RebalanceListener.OnPartitionRevoked on JVM
         private void PartitionsRevokedHandler(IImmutableSet<TopicPartitionOffset> partitions)
         {
-            if(_log.IsDebugEnabled)
+            if (_log.IsDebugEnabled)
                 _log.Debug($"Partitions were revoked: {string.Join(", ", partitions)}");
             var watch = Stopwatch.StartNew();
             _partitionEventHandler.OnRevoke(partitions, _restrictedConsumer);
             watch.Stop();
             CheckDuration(watch, "onRevoke");
-            
+
             _commitRefreshing.Revoke(partitions.Select(tp => tp.TopicPartition).ToImmutableHashSet());
             _rebalanceInProgress.GetAndSet(true);
         }
@@ -147,22 +156,22 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
         // This is RebalanceListener.OnPartitionLost on JVM
         private void PartitionsLostHandler(IImmutableSet<TopicPartitionOffset> partitions)
         {
-            if(_log.IsDebugEnabled)
+            if (_log.IsDebugEnabled)
                 _log.Debug($"Partitions were lost: {string.Join(", ", partitions)}");
             var watch = Stopwatch.StartNew();
             _partitionEventHandler.OnLost(partitions, _restrictedConsumer);
             watch.Stop();
             CheckDuration(watch, "onLost");
-            
+
             _commitRefreshing.Revoke(partitions.Select(tp => tp.TopicPartition).ToImmutableHashSet());
             _rebalanceInProgress.GetAndSet(true);
         }
-        
+
         private void RebalancePostStop()
         {
             var currentTopicPartitions = _consumer.Assignment.ToImmutableList();
             PausePartitions(currentTopicPartitions);
-            
+
             var watch = Stopwatch.StartNew();
             _partitionEventHandler.OnStop(currentTopicPartitions.ToImmutableHashSet(), _restrictedConsumer);
             watch.Stop();
@@ -173,12 +182,13 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
         {
             if (watch.Elapsed > _warningDuration)
             {
-                _log.Warning("Partition assignment handler `{0}` took longer than `partition-handler-warning`: {1} ms", method, watch.ElapsedMilliseconds);
+                _log.Warning("Partition assignment handler `{0}` took longer than `partition-handler-warning`: {1} ms",
+                    method, watch.ElapsedMilliseconds);
             }
-        }        
+        }
 
         #endregion
-        
+
         protected override bool Receive(object message)
         {
             switch (message)
@@ -187,34 +197,35 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                     _rebalanceCommitStash = _rebalanceCommitStash.Union(commit.Offsets);
                     _rebalanceCommitSenders = _rebalanceCommitSenders.Add(Sender);
                     return true;
-                
+
                 case KafkaConsumerActorMetadata.Internal.Commit commit:
                     _commitRefreshing.Add(commit.Offsets);
                     var replyTo = Sender;
                     Commit(commit.Offsets, msg => replyTo.Tell(msg));
                     return true;
-                
+
                 case Internal.Poll<K, V> poll:
                     ReceivePoll(poll);
                     return true;
-                
+
                 case KafkaConsumerActorMetadata.Internal.ISubscriptionRequest subscribe:
                     HandleSubscription(subscribe);
                     return true;
-                
+
                 case KafkaConsumerActorMetadata.Internal.RegisterSubStage subStage:
                     _stageActorsMap = _stageActorsMap.SetItem(subStage.TopicPartitions, Sender);
                     return true;
-                
+
                 case KafkaConsumerActorMetadata.Internal.RequestMessages requestMessages:
-                    if(_settings.VerboseLogging)
-                        _log.Debug("Messages was requested, RequestId: {0}, Partitions: {1}", requestMessages.RequestId, string.Join(", ", requestMessages.Topics));
+                    if (_settings.VerboseLogging)
+                        _log.Debug("Messages was requested, RequestId: {0}, Partitions: {1}", requestMessages.RequestId,
+                            string.Join(", ", requestMessages.Topics));
                     Context.Watch(Sender);
                     CheckOverlappingRequests("RequestMessages", Sender, requestMessages.Topics);
-                    
-                    if(_stageActorsMap.TryGetValue(requestMessages.Topics, out var sender) && sender == Sender)
+
+                    if (_stageActorsMap.TryGetValue(requestMessages.Topics, out var sender) && sender == Sender)
                         _requests = _requests.SetItem(Sender, requestMessages);
-                    
+
                     // When many requestors, e.g. many partitions with committablePartitionedSource the
                     // performance is much by collecting more requests/commits before performing the poll.
                     // That is done by sending a message to self, and thereby collect pending messages in mailbox.
@@ -226,26 +237,36 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                     {
                         RequestDelayedPoll();
                     }
+
                     return true;
-                
+
                 case KafkaConsumerActorMetadata.Internal.Seek seek:
-                    foreach (var offset in seek.Offsets)
+                    try
                     {
-                        _seekedOffset = _seekedOffset.SetItem(offset.TopicPartition, offset);
+                        foreach (var offset in seek.Offsets)
+                        {
+                            _seekedOffset = _seekedOffset.SetItem(offset.TopicPartition, offset);
+                        }
+
+                        Sender.Tell(Done.Instance);
                     }
-                    Sender.Tell(Done.Instance);
-                    return true;
+                    catch (Exception ex)
+                    {
+                        SendFailure(ex, Sender);
+                    }
                     
-                
+                    return true;
+
+
                 case KafkaConsumerActorMetadata.Internal.Committed committed:
                     _commitRefreshing.Committed(committed.Offsets);
                     return true;
-                
-                case KafkaConsumerActorMetadata.Internal.Stop _:
+
+                case KafkaConsumerActorMetadata.Internal.Stop:
                     _log.Debug($"Received Stop from {Sender}, stopping");
                     Context.Stop(Self);
                     return true;
-                
+
                 case KafkaConnectionFailed kcf:
                     ProcessError(kcf);
                     Self.Tell(KafkaConsumerActorMetadata.Internal.Stop.Instance);
@@ -260,12 +281,12 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                 case Metadata.IRequest req:
                     Sender.Tell(HandleMetadataRequest(req));
                     return true;
-                
+
                 default:
                     return false;
             }
         }
-       
+
         protected override void PreStart()
         {
             base.PreStart();
@@ -299,12 +320,15 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                     partitionLostHandler: (c, tp) => PartitionsLostHandler(tp.ToImmutableHashSet()),
                     statisticHandler: (c, json) => _statisticsHandler.OnStatistics(c, json));
 
-                var restrictedConsumerTimeoutMs = Math.Round(_settings.PartitionHandlerWarning.TotalMilliseconds * 0.95);
-                _restrictedConsumer = new RestrictedConsumer<K, V>(_consumer, TimeSpan.FromMilliseconds(restrictedConsumerTimeoutMs));
-                
+                var restrictedConsumerTimeoutMs =
+                    Math.Round(_settings.PartitionHandlerWarning.TotalMilliseconds * 0.95);
+                _restrictedConsumer =
+                    new RestrictedConsumer<K, V>(_consumer, TimeSpan.FromMilliseconds(restrictedConsumerTimeoutMs));
+
                 if (_settings.ConnectionCheckerSettings.Enabled)
                 {
-                    _connectionCheckerActor = Context.ActorOf(ConnectionChecker.Props(_settings.ConnectionCheckerSettings));
+                    _connectionCheckerActor =
+                        Context.ActorOf(ConnectionChecker.Props(_settings.ConnectionCheckerSettings));
                 }
             }
             catch (Exception e)
@@ -320,7 +344,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
             try
             {
                 Timers.CancelAll(); // Stop existing scheduling, if any
-                
+
                 if (_settings.ConnectionCheckerSettings.Enabled)
                 {
                     _connectionCheckerActor.Tell(KafkaConsumerActorMetadata.Internal.Stop.Instance);
@@ -339,11 +363,23 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
             finally
             {
                 // Make sure that the consumer is unassigned from the partition AND closed before we dispose
-                try { _consumer.Unassign(); }
-                catch (Exception) { /* no-op */ }
+                try
+                {
+                    _consumer.Unassign();
+                }
+                catch (Exception)
+                {
+                    /* no-op */
+                }
 
-                try { _consumer.Close(); }
-                catch (Exception) { /* no-op */ }
+                try
+                {
+                    _consumer.Close();
+                }
+                catch (Exception)
+                {
+                    /* no-op */
+                }
 
                 _consumer.Dispose();
             }
@@ -360,22 +396,25 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                         CheckOverlappingRequests("Assign", Sender, assign.TopicPartitions);
                         var previousAssigned = _consumer.Assignment;
                         _consumer.Assign(assign.TopicPartitions.Union(previousAssigned));
-                        _commitRefreshing.AssignedPositions(assign.TopicPartitions, _consumer, _settings.PositionTimeout);
+                        _commitRefreshing.AssignedPositions(assign.TopicPartitions, _consumer,
+                            _settings.PositionTimeout);
                         break;
                     }
 
                     case KafkaConsumerActorMetadata.Internal.AssignWithOffset assignWithOffset:
                     {
-                        var topicPartitions = assignWithOffset.TopicPartitionOffsets.Select(o => o.TopicPartition).ToImmutableHashSet();
+                        var topicPartitions = assignWithOffset.TopicPartitionOffsets.Select(o => o.TopicPartition)
+                            .ToImmutableHashSet();
                         CheckOverlappingRequests("AssignWithOffset", Sender, topicPartitions);
-                        
+
                         // TODO: dear lord this is wrong, WE SHOULD NOT BE SETTING OFFSETS TO ZERO HERE
-                        var previousAssigned = _consumer.Assignment.Select(tp => new TopicPartitionOffset(tp, new Offset(0)));
+                        var previousAssigned =
+                            _consumer.Assignment.Select(tp => new TopicPartitionOffset(tp, new Offset(0)));
                         _consumer.Assign(assignWithOffset.TopicPartitionOffsets.Union(previousAssigned));
                         _commitRefreshing.AssignedPositions(topicPartitions, assignWithOffset.TopicPartitionOffsets);
                         break;
                     }
-                    
+
                     case KafkaConsumerActorMetadata.Internal.Subscribe subscribe:
                     {
                         _consumer.Subscribe(subscribe.Topics);
@@ -395,7 +434,8 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
             }
             catch (Exception ex)
             {
-                ProcessError(ex);
+                // only this sender needs to be notified about the failure
+                SendFailure(ex, Sender);
             }
         }
 
@@ -419,7 +459,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
 
         private void ScheduleFirstPollTask()
         {
-            if(!Timers.IsTimerActive(PollTimerKey))
+            if (!Timers.IsTimerActive(PollTimerKey))
                 SchedulePollTask();
         }
 
@@ -438,17 +478,19 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
             }
         }
 
-        private void CheckOverlappingRequests(string updateType, IActorRef fromStage, IImmutableSet<TopicPartition> topics)
+        private void CheckOverlappingRequests(string updateType, IActorRef fromStage,
+            IImmutableSet<TopicPartition> topics)
         {
             // check if same topics/partitions have already been requested by someone else,
             // which is an indication that something is wrong, but it might be alright when assignments change.
-            foreach (var (actorRef, request) in _requests.ToTuples())
+            foreach (var (actorRef, request) in _requests)
             {
                 if (!actorRef.Equals(fromStage) && request.Topics.Any(topics.Contains))
                 {
                     _log.Warning($"{updateType} from topic/partition {string.Join(", ", topics)} " +
                                  $"already requested by other stage {string.Join(", ", request.Topics)}");
-                    actorRef.Tell(new KafkaConsumerActorMetadata.Internal.Messages<K, V>(request.RequestId, ImmutableList<ConsumeResult<K, V>>.Empty));
+                    actorRef.Tell(new KafkaConsumerActorMetadata.Internal.Messages<K, V>(request.RequestId,
+                        ImmutableList<ConsumeResult<K, V>>.Empty));
                     _requests = _requests.Remove(actorRef);
                 }
             }
@@ -465,9 +507,9 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                     _log.Debug("Refreshing committed offsets: {0}", refreshOffsets.JoinToString(", "));
                     Commit(refreshOffsets, msg => Context.System.DeadLetters.Tell(msg));
                 }
-               
+
                 Poll();
-               
+
                 if (poll.Periodic)
                     SchedulePollTask();
                 else
@@ -488,10 +530,10 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
             var partitionsToFetch = _requests.Values.SelectMany(v => v.Topics)
                 .Where(p => currentAssignment.Contains(p))
                 .ToImmutableHashSet();
-            
+
             if (partitionsToFetch.IsEmpty || _requests.IsEmpty())
             {
-                if(_settings.VerboseLogging)
+                if (_settings.VerboseLogging)
                     _log.Debug("Requests are empty - attempting to consume.");
                 PausePartitions(currentAssignment);
                 try
@@ -516,8 +558,9 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                 {
                     try
                     {
-                        if(_log.IsDebugEnabled)
-                            _log.Debug("Seeking offset {0} in partition {1} for topic {2}", tpo.Offset, tpo.Partition, tpo.Topic);
+                        if (_log.IsDebugEnabled)
+                            _log.Debug("Seeking offset {0} in partition {1} for topic {2}", tpo.Offset, tpo.Partition,
+                                tpo.Topic);
                         _consumer.Seek(tpo);
                     }
                     catch (Exception ex)
@@ -526,10 +569,11 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                         throw;
                     }
                 }
-                
+
                 // resume partitions to fetch
                 var (resumeThese, pauseThese) = currentAssignment.Partition(partitionsToFetch.Contains);
-                PausePartitions(pauseThese); // SHOULD PAUSE ANY PARTITIONS THAT HAVE BEEN ASSIGNED BUT ARE NOT REQUESTED
+                PausePartitions(
+                    pauseThese); // SHOULD PAUSE ANY PARTITIONS THAT HAVE BEEN ASSIGNED BUT ARE NOT REQUESTED
                 ResumePartitions(resumeThese);
 
                 using (var cts = new CancellationTokenSource(_settings.PollTimeout))
@@ -548,7 +592,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                         ProcessExceptions(exception);
                 }
             }
-            
+
             CheckRebalanceState(initialRebalanceInProcess);
 
             if (_stopInProgress)
@@ -561,7 +605,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
         private (List<ConsumeResult<K, V>>, Exception?) PollKafka(CancellationToken token)
         {
             var i = 10; // 10 poll attempts
-            var timeout = Math.Max((int) _pollTimeout.TotalMilliseconds / i, 1);
+            var timeout = Math.Max((int)_pollTimeout.TotalMilliseconds / i, 1);
             var polled = new List<ConsumeResult<K, V>>();
             do
             {
@@ -575,6 +619,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                         _pausedPartitions = ImmutableList<TopicPartition>.Empty;
                         return (polled, null);
                     }
+
                     polled.Add(consumed);
                     i--;
                 }
@@ -587,21 +632,21 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
             return (polled, null);
         }
 
-        private void ProcessResult(IImmutableSet<TopicPartition> partitionsToFetch, List<ConsumeResult<K,V>> rawResult)
+        private void ProcessResult(IImmutableSet<TopicPartition> partitionsToFetch, List<ConsumeResult<K, V>> rawResult)
         {
-            if(_log.IsDebugEnabled)
+            if (_log.IsDebugEnabled)
                 _log.Debug("Processing poll result with {0} records", rawResult.Count);
 
-            if(rawResult.IsEmpty())
+            if (rawResult.IsEmpty())
                 return;
-            
+
             var fetchedTps = rawResult.Select(m => m.TopicPartition).ToImmutableSet();
             if (!fetchedTps.Except(partitionsToFetch).IsEmpty())
                 throw new ArgumentException(
                     $"Unexpected records polled. Expected: [{string.Join(", ", partitionsToFetch.Select(p => p.ToString()))}], " +
                     $"result: [{string.Join(", ", fetchedTps.Select(p => p.ToString()))}], " +
                     $"consumer assignment: [{string.Join(", ", _consumer.Assignment.Select(p => p.ToString()))}]");
-                    
+
             //send messages to actors
             foreach (var (stageActorRef, request) in _requests.ToTuples())
             {
@@ -609,36 +654,47 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                 foreach (var message in rawResult)
                 {
                     var currentTp = message.TopicPartition;
-                    
+
                     if (_seekedOffset.TryGetValue(currentTp, out var seekedTpo))
                     {
                         if (message.Offset != seekedTpo.Offset)
                             throw new Exception("Seek failed, received message offset is greater than seek offset");
                         _seekedOffset = _seekedOffset.Remove(currentTp);
                     }
-                    
+
                     // If requestor is interested in consumed topic, send him consumed result
                     if (request.Topics.Contains(currentTp))
                     {
                         messages.Add(message);
                     }
                 }
-                
-                if(!messages.IsEmpty())
+
+                if (!messages.IsEmpty())
                 {
-                    stageActorRef.Tell(new KafkaConsumerActorMetadata.Internal.Messages<K, V>(request.RequestId, messages.ToImmutableList()));
+                    stageActorRef.Tell(
+                        new KafkaConsumerActorMetadata.Internal.Messages<K, V>(request.RequestId,
+                            messages.ToImmutableList()));
                     _requests = _requests.Remove(stageActorRef);
                 }
-            }                    
+            }
         }
-        
+
+        private void SendFailure(Exception ex, IActorRef stageActorRef)
+        {
+            stageActorRef.Tell(new Status.Failure(ex));
+            _stageActorsMap = _stageActorsMap.Where(c => !c.Value.Equals(stageActorRef)).ToImmutableDictionary();
+        }
+
         private void ProcessError(Exception error)
         {
-            var involvedStageActors = _requests.Keys.Append(_owner).Where(actor => actor is not null).ToImmutableHashSet();
-            _log.Debug($"Sending failure to {involvedStageActors.JoinToString(", ")}. Error: {error}");
-            foreach (var actor in involvedStageActors)
+            var sendTo = _stageActorsMap.Values.ToImmutableSet();
+            if (_owner != null)
+                sendTo = sendTo.Add(_owner);
+
+            _log.Debug(error, "Sending failure {0} to {1}.", error.GetType(), string.Join(", ", sendTo));
+            foreach (var actor in sendTo)
             {
-                actor.Tell(new Status.Failure(error));
+                SendFailure(error, actor);
             }
         }
 
@@ -646,15 +702,17 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
         {
             try
             {
-                _commitRefreshing.UpdateRefreshDeadlines(commitMap.Select(tp => tp.TopicPartition).ToImmutableHashSet());
+                _commitRefreshing.UpdateRefreshDeadlines(commitMap.Select(tp => tp.TopicPartition)
+                    .ToImmutableHashSet());
 
                 var watch = Stopwatch.StartNew();
-                
+
                 _consumer.Commit(commitMap);
-                
+
                 watch.Stop();
                 if (watch.Elapsed >= _settings.CommitTimeWarning)
-                    _log.Warning($"Kafka commit took longer than `commit-time-warning`: {watch.ElapsedMilliseconds} ms");
+                    _log.Warning(
+                        $"Kafka commit took longer than `commit-time-warning`: {watch.ElapsedMilliseconds} ms");
 
                 Self.Tell(new KafkaConsumerActorMetadata.Internal.Committed(commitMap));
                 sendReply(Akka.Done.Instance);
@@ -684,7 +742,8 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
         {
             if (initialRebalanceInProgress && !_rebalanceInProgress.Value && _rebalanceCommitSenders.Any())
             {
-                _log.Debug($"Comitting stash {string.Join(", ", _rebalanceCommitStash)} replying to {string.Join(", ", _rebalanceCommitSenders)}");
+                _log.Debug(
+                    $"Comitting stash {string.Join(", ", _rebalanceCommitStash)} replying to {string.Join(", ", _rebalanceCommitSenders)}");
                 var replyTo = _rebalanceCommitSenders;
                 Commit(_rebalanceCommitStash, msg => replyTo.ForEach(actor => actor.Tell(msg)));
                 _rebalanceCommitStash = ImmutableHashSet<TopicPartitionOffset>.Empty;
@@ -696,8 +755,8 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
         {
             if (partitions.Count == 0)
                 return;
-            
-            if(_settings.VerboseLogging)
+
+            if (_settings.VerboseLogging)
                 _log.Debug("Pausing partitions [{0}]", string.Join(",", partitions));
             _consumer.Pause(partitions);
         }
@@ -706,8 +765,8 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
         {
             if (partitions.Count == 0)
                 return;
-            
-            if(_settings.VerboseLogging)
+
+            if (_settings.VerboseLogging)
                 _log.Debug("Resuming partitions [{0}]", string.Join(",", partitions));
             _consumer.Resume(partitions);
         }
@@ -721,16 +780,16 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
             ProcessError(exception);
             if (directive == Directive.Resume)
                 return;
-            
+
             Timers.CancelAll();
-            if(directive == Directive.Stop && _log.IsErrorEnabled)
+            if (directive == Directive.Stop && _log.IsErrorEnabled)
                 _log.Error(exception, "Exception when polling from consumer, stopping actor: {0}", exception.Message);
             Context.Stop(Self);
         }
 
         static class Internal
         {
-            public class Poll<TPollKey, TPollValue> 
+            public class Poll<TPollKey, TPollValue>
                 where TPollKey : K
                 where TPollValue : V
             {
@@ -744,6 +803,5 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                 public bool Periodic { get; }
             }
         }
-
     }
 }

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
@@ -223,7 +223,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                     Context.Watch(Sender);
                     CheckOverlappingRequests("RequestMessages", Sender, requestMessages.Topics);
 
-                    if (_stageActorsMap.TryGetValue(requestMessages.Topics, out var sender) && sender == Sender)
+                    if (_stageActorsMap.GetOrElse(requestMessages.Topics, Sender).Equals(Sender))
                         _requests = _requests.SetItem(Sender, requestMessages);
 
                     // When many requestors, e.g. many partitions with committablePartitionedSource the

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
@@ -407,13 +407,9 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                             .ToImmutableHashSet();
                         CheckOverlappingRequests("AssignWithOffset", Sender, topicPartitions);
 
-                        var previousAssigned =
-                            _consumer.Assignment;
-                        _consumer.Assign(topicPartitions.Union(previousAssigned));
-                        foreach (var offset in assignWithOffset.TopicPartitionOffsets)
-                        {
-                            _consumer.Seek(offset);
-                        }
+                        var previousAssigned = _consumer.Assignment
+                            .Select(c => new TopicPartitionOffset(c, Offset.Stored));
+                        _consumer.Assign(assignWithOffset.TopicPartitionOffsets.Union(previousAssigned));
                         _commitRefreshing.AssignedPositions(topicPartitions, assignWithOffset.TopicPartitionOffsets);
                         break;
                     }
@@ -437,11 +433,6 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
             }
             catch (Exception ex)
             {
-                if (ex is KafkaException kafkaException)
-                {
-                    _log.Error(kafkaException, "Received Kafka broker exception: {0}, [{1}]", kafkaException.Message, kafkaException.Error);
-                }
-                
                 // only this sender needs to be notified about the failure
                 SendFailure(ex, Sender);
             }

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
@@ -407,10 +407,13 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                             .ToImmutableHashSet();
                         CheckOverlappingRequests("AssignWithOffset", Sender, topicPartitions);
 
-                        // TODO: dear lord this is wrong, WE SHOULD NOT BE SETTING OFFSETS TO ZERO HERE
                         var previousAssigned =
-                            _consumer.Assignment.Select(tp => new TopicPartitionOffset(tp, new Offset(0)));
-                        _consumer.Assign(assignWithOffset.TopicPartitionOffsets.Union(previousAssigned));
+                            _consumer.Assignment;
+                        _consumer.Assign(topicPartitions.Union(previousAssigned));
+                        foreach (var offset in assignWithOffset.TopicPartitionOffsets)
+                        {
+                            _consumer.Seek(offset);
+                        }
                         _commitRefreshing.AssignedPositions(topicPartitions, assignWithOffset.TopicPartitionOffsets);
                         break;
                     }

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
@@ -217,10 +217,9 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                     {
                         Poll();
                     }
-                    else if (!_delayedPollInFlight)
+                    else
                     {
-                        _delayedPollInFlight = true;
-                        Self.Tell(_delayedPollMessage);
+                        RequestDelayedPoll();
                     }
                     return true;
                 
@@ -422,6 +421,15 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
         {
             Timers.CancelAll();
             Timers.StartSingleTimer(PollTimerKey, _pollMessage, _settings.PollInterval);
+        }
+
+        private void RequestDelayedPoll()
+        {
+            if (_delayedPollInFlight)
+            {
+                _delayedPollInFlight = true;
+                Self.Tell(_delayedPollMessage);
+            }
         }
 
         private void CheckOverlappingRequests(string updateType, IActorRef fromStage, IImmutableSet<TopicPartition> topics)
@@ -657,10 +665,9 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
             {
                 Poll();
             }
-            else if (!_delayedPollInFlight)
+            else
             {
-                _delayedPollInFlight = true;
-                Self.Tell(_delayedPollMessage);
+                RequestDelayedPoll();
             }
         }
 

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
@@ -46,10 +46,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
         private readonly Internal.Poll<K, V> _delayedPollMessage;
 
         private TimeSpan _pollTimeout;
-
-        private ImmutableDictionary<TopicPartition, TopicPartitionOffset> _seekedOffset =
-            ImmutableDictionary<TopicPartition, TopicPartitionOffset>.Empty;
-
+        
         /// <summary>
         /// Limits the blocking on position in [[RebalanceListenerImpl]]
         /// </summary>
@@ -634,13 +631,6 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                 foreach (var message in rawResult)
                 {
                     var currentTp = message.TopicPartition;
-
-                    if (_seekedOffset.TryGetValue(currentTp, out var seekedTpo))
-                    {
-                        if (message.Offset != seekedTpo.Offset)
-                            throw new Exception("Seek failed, received message offset is greater than seek offset");
-                        _seekedOffset = _seekedOffset.Remove(currentTp);
-                    }
 
                     // If requestor is interested in consumed topic, send him consumed result
                     if (request.Topics.Contains(currentTp))

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
@@ -245,7 +245,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                     {
                         foreach (var offset in seek.Offsets)
                         {
-                            _seekedOffset = _seekedOffset.SetItem(offset.TopicPartition, offset);
+                            _consumer.Seek(offset);
                         }
 
                         Sender.Tell(Done.Instance);
@@ -549,26 +549,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                 }
             }
             else
-            {
-                // Seek has to be done here because they can somehow fail.
-                // Would need to see if we can move this somewhere else
-                // because a seek can take up to 200ms to complete
-                foreach (var tpo in _seekedOffset.Select(kvp => kvp.Value))
-                {
-                    try
-                    {
-                        if (_log.IsDebugEnabled)
-                            _log.Debug("Seeking offset {0} in partition {1} for topic {2}", tpo.Offset, tpo.Partition,
-                                tpo.Topic);
-                        _consumer.Seek(tpo);
-                    }
-                    catch (Exception ex)
-                    {
-                        _log.Error(ex, $"{tpo.TopicPartition} Failed to seek to {tpo.Offset}: {ex}");
-                        throw;
-                    }
-                }
-
+            {   
                 // resume partitions to fetch
                 var (resumeThese, pauseThese) = currentAssignment.Partition(partitionsToFetch.Contains);
                 PausePartitions(

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActorMetadata.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActorMetadata.cs
@@ -75,6 +75,9 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
 
                 private Stop() { }
             }
+
+            public sealed record RegisterSubStage(IImmutableSet<TopicPartition> TopicPartitions)
+                : INoSerializationVerificationNeeded;
             
             public sealed record Seek(IImmutableSet<TopicPartitionOffset> Offsets) : INoSerializationVerificationNeeded;
             /// <summary>

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Concrete/CommittableSubSourceStage.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Concrete/CommittableSubSourceStage.cs
@@ -81,8 +81,6 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Concrete
         }
     }
 
-   
-
     internal sealed class CommittableSubSourceStageLogic<K, V> : SubSourceStageLogic<K, V, CommittableMessage<K, V>>
     {
         public CommittableSubSourceStageLogic(

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Concrete/CommittableSubSourceStage.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Concrete/CommittableSubSourceStage.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
+using Akka.Actor;
 using Akka.Streams.Dsl;
 using Akka.Streams.Kafka.Helpers;
 using Akka.Streams.Kafka.Messages;
@@ -13,44 +14,87 @@ using Confluent.Kafka;
 
 namespace Akka.Streams.Kafka.Stages.Consumers.Concrete
 {
-    public class CommittableSubSourceStage<K, V> : KafkaSourceStage<K, V, (TopicPartition, Source<CommittableMessage<K, V>, NotUsed>)>
+    public class
+        CommittableSubSourceStage<K, V> : KafkaSourceStage<K, V, (TopicPartition,
+        Source<CommittableMessage<K, V>, NotUsed>)>
     {
         private readonly Func<ConsumeResult<K, V>, string> _metadataFromRecord;
-        
+
         /// <summary>
         /// Consumer settings
         /// </summary>
         public ConsumerSettings<K, V> Settings { get; }
+
         /// <summary>
         /// Subscription
         /// </summary>
         public IAutoSubscription Subscription { get; }
 
-        public CommittableSubSourceStage(ConsumerSettings<K, V> settings, IAutoSubscription subscription, Func<ConsumeResult<K, V>, string>? metadataFromRecord = null) 
+        public CommittableSubSourceStage(ConsumerSettings<K, V> settings, IAutoSubscription subscription,
+            Func<ConsumeResult<K, V>, string>? metadataFromRecord = null)
             : base("CommittableSubSourceStage")
         {
             Settings = settings;
             Subscription = subscription;
             _metadataFromRecord = metadataFromRecord ?? (_ => string.Empty);
+            _subSourceStageLogicFactory = new CommittableSubSourceStageLogicFactory(Settings, _metadataFromRecord);
         }
 
-        protected override (GraphStageLogic, IControl) Logic(SourceShape<(TopicPartition, Source<CommittableMessage<K, V>, NotUsed>)> shape, Attributes inheritedAttributes)
+        private readonly SubSourceLogic.ISubSourceStageLogicFactory<K, V, CommittableMessage<K, V>> _subSourceStageLogicFactory;
+
+        protected override (GraphStageLogic, IControl) Logic(
+            SourceShape<(TopicPartition, Source<CommittableMessage<K, V>, NotUsed>)> shape,
+            Attributes inheritedAttributes)
         {
-            var logic = new SubSourceLogic<K, V, CommittableMessage<K, V>>(shape, Settings, Subscription, 
-                                                                           messageBuilderFactory: GetMessageBuilder, 
-                                                                           getOffsetsOnAssign: Option<Func<IImmutableSet<TopicPartition>, Task<IImmutableSet<TopicPartitionOffset>>>>.None, 
-                                                                           onRevoke: _ => { }, 
-                                                                           attributes: inheritedAttributes);
+            var logic = new SubSourceLogic<K, V, CommittableMessage<K, V>>(shape, Settings, Subscription,
+                getOffsetsOnAssign:
+                Option<Func<IImmutableSet<TopicPartition>, Task<IImmutableSet<TopicPartitionOffset>>>>.None,
+                onRevoke: _ => { },
+                _subSourceStageLogicFactory,
+                attributes: inheritedAttributes);
             return (logic, logic.Control);
         }
         
-        /// <summary>
-        /// Creates message builder for sub-source logic
-        /// </summary>
-        private CommittableSourceMessageBuilder<K, V> GetMessageBuilder(SubSourceLogic<K, V, CommittableMessage<K, V>> logic)
+        private class
+            CommittableSubSourceStageLogicFactory(ConsumerSettings<K, V> settings,  Func<ConsumeResult<K, V>, string> metadataFromRecord)
+            : SubSourceLogic.ISubSourceStageLogicFactory<K, V,
+                CommittableMessage<K, V>>
         {
-            var committer = new KafkaAsyncConsumerCommitter(() => logic.ConsumerActor, Settings.CommitTimeout);
-            return new CommittableSourceMessageBuilder<K, V>(committer, Settings.GroupId, _metadataFromRecord);
+            
+            
+            public SubSourceStageLogic<K, V, CommittableMessage<K, V>> Create(SourceShape<CommittableMessage<K, V>> shape,
+                TopicPartition tp, IActorRef consumerActor,
+                Action<SubSourceLogic.SubSourceStageLogicControl> subSourceStartedCb,
+                Action<(TopicPartition partition, SubSourceLogic.ISubSourceCancellationStrategy cancellationStrategy)>
+                    subSourceCancelledCb, int actorNumber) =>
+                new CommittableSubSourceStageLogic<K, V>(shape, tp, consumerActor, actorNumber, GetMessageBuilder(consumerActor, settings, metadataFromRecord),
+                    subSourceStartedCb, subSourceCancelledCb);
+            
+            /// <summary>
+            /// Creates message builder for sub-source logic
+            /// </summary>
+            private CommittableSourceMessageBuilder<K, V> GetMessageBuilder(IActorRef consumerActor, ConsumerSettings<K, V> consumerSettings,  Func<ConsumeResult<K, V>, string> metadataFromRecord)
+            {
+                var committer = new KafkaAsyncConsumerCommitter(() => consumerActor, consumerSettings.CommitTimeout);
+                return new CommittableSourceMessageBuilder<K, V>(committer, consumerSettings.GroupId,metadataFromRecord);
+            }
+        }
+    }
+
+   
+
+    internal sealed class CommittableSubSourceStageLogic<K, V> : SubSourceStageLogic<K, V, CommittableMessage<K, V>>
+    {
+        public CommittableSubSourceStageLogic(
+            SourceShape<CommittableMessage<K, V>> shape,
+            TopicPartition topicPartition,
+            IActorRef consumerActor, int actorNumber,
+            IMessageBuilder<K, V, CommittableMessage<K, V>> messageBuilder,
+            Action<SubSourceLogic.SubSourceStageLogicControl> subSourceStartedCallback,
+            Action<(TopicPartition, SubSourceLogic.ISubSourceCancellationStrategy)> subSourceCancelledCallback)
+            : base(shape, topicPartition, consumerActor, actorNumber, messageBuilder, subSourceStartedCallback,
+                subSourceCancelledCallback)
+        {
         }
     }
 }

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Concrete/PlainSubSourceStage.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Concrete/PlainSubSourceStage.cs
@@ -1,14 +1,13 @@
 using System;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
-using Akka.Event;
+using Akka.Actor;
 using Akka.Streams.Dsl;
 using Akka.Streams.Kafka.Dsl;
 using Akka.Streams.Kafka.Helpers;
 using Akka.Streams.Kafka.Settings;
 using Akka.Streams.Kafka.Stages.Consumers.Abstract;
 using Akka.Streams.Stage;
-using Akka.Streams.Util;
 using Akka.Util;
 using Confluent.Kafka;
 
@@ -38,9 +37,9 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Concrete
         /// </summary>
         public Action<IImmutableSet<TopicPartition>> OnRevoke { get; }
 
-        /// <summary>
-        /// PlainSubSourceStage
-        /// </summary>
+        private readonly SubSourceLogic.ISubSourceStageLogicFactory<K, V, ConsumeResult<K, V>>
+            _subSourceStageLogicFactory;
+        
         public PlainSubSourceStage(ConsumerSettings<K, V> settings, IAutoSubscription subscription, 
                                    Option<Func<IImmutableSet<TopicPartition>, Task<IImmutableSet<TopicPartitionOffset>>>> getOffsetsOnAssign,
                                    Action<IImmutableSet<TopicPartition>> onRevoke) 
@@ -50,19 +49,46 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Concrete
             Subscription = subscription;
             GetOffsetsOnAssign = getOffsetsOnAssign;
             OnRevoke = onRevoke;
+            _subSourceStageLogicFactory = new PlainSubSourceStageLogicFactory();
         }
 
-        /// <inheritdoc />
+        private class
+            PlainSubSourceStageLogicFactory : SubSourceLogic.ISubSourceStageLogicFactory<K, V, ConsumeResult<K, V>>
+        {
+            public SubSourceStageLogic<K, V, ConsumeResult<K, V>> Create(SourceShape<ConsumeResult<K, V>> shape,
+                TopicPartition tp, IActorRef consumerActor,
+                Action<SubSourceLogic.SubSourceStageLogicControl> subSourceStartedCb,
+                Action<(TopicPartition partition, SubSourceLogic.ISubSourceCancellationStrategy cancellationStrategy)>
+                    subSourceCancelledCb, int actorNumber) =>
+                new PlainSubSourceStageLogic<K, V>(shape, tp, consumerActor, actorNumber,
+                    new PlainMessageBuilder<K, V>(), subSourceStartedCb, subSourceCancelledCb);
+        }
+        
         protected override (GraphStageLogic, IControl) Logic(SourceShape<(TopicPartition, Source<ConsumeResult<K, V>, NotUsed>)> shape, 
                                                              Attributes inheritedAttributes)
         {
             var logic = new SubSourceLogic<K, V, ConsumeResult<K, V>>(shape, Settings, Subscription, 
-                                                                      messageBuilderFactory: _ => new PlainMessageBuilder<K, V>(), 
                                                                       getOffsetsOnAssign: GetOffsetsOnAssign, 
                                                                       onRevoke: OnRevoke, 
+                                                                      _subSourceStageLogicFactory,
                                                                       attributes: inheritedAttributes);
 
             return (logic, logic.Control);
+        }
+    }
+    
+    internal sealed class PlainSubSourceStageLogic<K, V> : SubSourceStageLogic<K, V, ConsumeResult<K, V>>
+    {
+        public PlainSubSourceStageLogic(
+            SourceShape<ConsumeResult<K, V>> shape,
+            TopicPartition topicPartition,
+            IActorRef consumerActor, int actorNumber,
+            IMessageBuilder<K, V, ConsumeResult<K, V>> messageBuilder,
+            Action<SubSourceLogic.SubSourceStageLogicControl> subSourceStartedCallback,
+            Action<(TopicPartition, SubSourceLogic.ISubSourceCancellationStrategy)> subSourceCancelledCallback)
+            : base(shape, topicPartition, consumerActor, actorNumber, messageBuilder, subSourceStartedCallback,
+                subSourceCancelledCallback)
+        {
         }
     }
 }


### PR DESCRIPTION
## Changes

Numerous bug fixes and consistency issue fixes here. #415 still has not been addressed but I'm working my way towards that.

partially resolves #447 

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
