### PR TITLE
Resolve `ArgumentException` upon partition re-assignment

### DIFF
--- a/src/Akka.Streams.Kafka/Extensions/CollectionExtensions.cs
+++ b/src/Akka.Streams.Kafka/Extensions/CollectionExtensions.cs
@@ -43,7 +43,7 @@ namespace Akka.Streams.Kafka.Extensions
         /// <summary>
         /// Split a list into two list depending on the boolean return value of the predicate.
         /// </summary>
-        public static (IImmutableList<T> True, IImmutableList<T> False) Partition<T>(this IImmutableList<T> list, Predicate<T> predicate)
+        public static (IImmutableList<T> True, IImmutableList<T> False) Partition<T>(this IReadOnlyCollection<T> list, Predicate<T> predicate)
         {
             var left = new List<T>();
             var right = new List<T>();

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
@@ -622,14 +622,17 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                         var newlyAssignedButNotRequested = newlyAssigned.Except(partitionsToFetch);
                         if (newlyAssignedButNotRequested.Any())
                         {
-                            var originalUnrequestedCount = _unRequestedMessages.Count;
                             var (newUnrequested, requested) = polled.Partition(c => newlyAssignedButNotRequested.Contains(c.TopicPartition));
-                            _unRequestedMessages = _unRequestedMessages.AddRange(newUnrequested);
-                            var totalNewUnrequested = _unRequestedMessages.Count - originalUnrequestedCount;
-                            _log.Info("Stashing [{0}] messages for newly assigned but not requested partitions: {1} - [{2}] total unrequested messages",
-                               totalNewUnrequested,  string.Join(", ", newlyAssignedButNotRequested), _unRequestedMessages.Count);
+                            if (newUnrequested.Count > 0)
+                            {
+                                var originalUnrequestedCount = _unRequestedMessages.Count;
+                                _unRequestedMessages = _unRequestedMessages.AddRange(newUnrequested);
+                                var totalNewUnrequested = _unRequestedMessages.Count - originalUnrequestedCount;
+                                _log.Info("Stashing [{0}] messages for newly assigned but not requested partitions: {1} - [{2}] total unrequested messages",
+                                    totalNewUnrequested,  string.Join(", ", newlyAssignedButNotRequested), _unRequestedMessages.Count);
 
-                            polled = requested;
+                                polled = requested;
+                            }
                         }
                     }
                     

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
@@ -143,7 +143,8 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
         {
             if (_log.IsDebugEnabled)
                 _log.Debug($"Partitions were assigned: {string.Join(", ", partitions)}");
-
+            // NOTE: we can't pause partitions here even though it's the right thing to do because the Kafka client will err out
+            
             _commitRefreshing.AssignedPositions(partitions, _consumer, _settings.PositionTimeout);
 
             // clean up any unrequestedMessages belonging to revokedPartitions

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
@@ -670,7 +670,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                 {
                     // this would return immediately if there are messages waiting inside the client queue buffer
                     var consumed = _consumer.Consume(timeout);
-                    if (consumed is null || _rebalanceInProgress) // bail out if we detect the start of a re-balance
+                    if (consumed is null)
                     {
                         return (polled, null);
                     }

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
@@ -589,7 +589,17 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                 {
                     var consumed = _consumer.Consume(0);
                     if (consumed is not null)
-                        throw new IllegalActorStateException("Consumed message should be null");
+                    {
+                        /*
+                         * We would normally expect a null result here, but it's totally possible for a partition
+                         * assignment + a message from that partition to arrive in the same Consume(0) call.
+                         * Were that to happen, we need to stash the message for future processing.
+                         */
+                        _unRequestedMessages = _unRequestedMessages.Add(consumed);
+                        _log.Info("Received [1] message from unrequested partition: {0} - stashing for later processing. " +,
+                                  "Total unrequested messages: {1}",
+                            consumed.TopicPartition, _unRequestedMessages.Count);
+                    }
                 }
                 catch (Exception e)
                 {

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Akka.Actor;
+using Akka.Streams.Implementation.Fusing;
 using Akka.Streams.Kafka.Extensions;
 using Akka.Streams.Kafka.Helpers;
 using Akka.Streams.Kafka.Internal;
@@ -46,7 +47,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
         private readonly Internal.Poll<K, V> _delayedPollMessage;
 
         private TimeSpan _pollTimeout;
-        
+
         /// <summary>
         /// Limits the blocking on position in [[RebalanceListenerImpl]]
         /// </summary>
@@ -86,11 +87,29 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
             _rebalanceCommitStash = ImmutableHashSet<TopicPartitionOffset>.Empty;
 
         /// <summary>
+        /// Some important behavioral difference between the .NET and Java Kafka SDKs:
+        ///
+        /// 1.  Pausing partitions does not guarantee that previously retrieved messages stored
+        ///     inside <see cref="_consumer"/>'s buffer won't be returned.
+        /// 2.  The .NET SDK works from single messages rather than batches, therefore it is totally
+        ///     possible that assignment / re-balance events may occur in the middle of gathering messages
+        ///     via single Consume(int) calls.
+        /// 3. Therefore, it's possible that we will receive messages from partitions that have been
+        ///     assigned but not requested. Therefore, we need to make sure we buffer these messages until
+        ///     the <see cref="KafkaConsumerActorMetadata.Internal.RequestMessages"/> comes in.
+        ///
+        /// That's what this data structure is for - effectively it's a small stash of messages that have
+        /// been sent but not requested. This is designed to help us prevent issues such as
+        /// https://github.com/akkadotnet/Akka.Streams.Kafka/issues/415 from prematurely terminating consumers.
+        /// </summary>
+        private IImmutableList<ConsumeResult<K, V>> _unRequestedMessages = ImmutableList<ConsumeResult<K, V>>.Empty;
+
+        /// <summary>
         /// Keeps commit senders that need a reply once stashed commits are made.
         /// </summary>
         private IImmutableList<IActorRef> _rebalanceCommitSenders = ImmutableArray<IActorRef>.Empty;
 
-        private ImmutableList<TopicPartition> _pausedPartitions = ImmutableList<TopicPartition>.Empty;
+        private ImmutableList<TopicPartition> _revokedPartitions = ImmutableList<TopicPartition>.Empty;
 
         /// <summary>
         /// KafkaConsumerActor
@@ -124,10 +143,18 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
         {
             if (_log.IsDebugEnabled)
                 _log.Debug($"Partitions were assigned: {string.Join(", ", partitions)}");
-            _pausedPartitions = partitions.ToImmutableList();
 
             _commitRefreshing.AssignedPositions(partitions, _consumer, _settings.PositionTimeout);
 
+            // clean up any unrequestedMessages belonging to revokedPartitions
+            if (_unRequestedMessages.Count > 0)
+            {
+                // get revoked partitions that do not appear in the assigned partitions list
+                var trulyRevokedPartitions = _revokedPartitions.Except(partitions);
+                _unRequestedMessages = _unRequestedMessages.Where(m => !trulyRevokedPartitions.Contains(m.TopicPartition))
+                    .ToImmutableList();
+            }
+               
             var watch = Stopwatch.StartNew();
             _partitionEventHandler.OnAssign(partitions, _restrictedConsumer);
             watch.Stop();
@@ -141,6 +168,9 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
         {
             if (_log.IsDebugEnabled)
                 _log.Debug($"Partitions were revoked: {string.Join(", ", partitions)}");
+
+            // keep track of which partitions are being revoked, so we can clean up our "unrequested messages"
+            _revokedPartitions = partitions.Select(tp => tp.TopicPartition).ToImmutableList();
             var watch = Stopwatch.StartNew();
             _partitionEventHandler.OnRevoke(partitions, _restrictedConsumer);
             watch.Stop();
@@ -155,6 +185,15 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
         {
             if (_log.IsDebugEnabled)
                 _log.Debug($"Partitions were lost: {string.Join(", ", partitions)}");
+            
+            if (_unRequestedMessages.Count > 0)
+            {
+                // immediately clean up any unrequestedMessages belonging to lost partitions
+                var lostPartitions = partitions.Select(tp => tp.TopicPartition).ToImmutableHashSet();
+                _unRequestedMessages = _unRequestedMessages.Where(m => !lostPartitions.Contains(m.TopicPartition))
+                    .ToImmutableList();
+            }
+           
             var watch = Stopwatch.StartNew();
             _partitionEventHandler.OnLost(partitions, _restrictedConsumer);
             watch.Stop();
@@ -222,6 +261,23 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
 
                     if (_stageActorsMap.GetOrElse(requestMessages.Topics, Sender).Equals(Sender))
                         _requests = _requests.SetItem(Sender, requestMessages);
+                    
+                    /* UNREQUESTED MESSAGES CHECK */
+                    if (_unRequestedMessages.Count > 0)
+                    {
+                        var (requested, unrequested) = _unRequestedMessages.Partition(m => requestMessages.Topics.Contains(m.TopicPartition));
+                        _unRequestedMessages = unrequested;
+                        if (requested.Count > 0)
+                        {
+                            _log.Info("Found [{0}] unrequested messages for requested partitions: {1} - [{2}] total remaining unrequested messages",
+                                requested.Count, string.Join(", ", requestMessages.Topics), _unRequestedMessages.Count);
+                            Sender.Tell(new KafkaConsumerActorMetadata.Internal.Messages<K, V>(requestMessages.RequestId, requested.ToImmutableList()));
+                            _requests = _requests.Remove(Sender);
+                            
+                            // not going to schedule a poll of any kind here - wait until we receive the next request
+                            return true;
+                        }
+                    }
 
                     // When many requestors, e.g. many partitions with committablePartitionedSource the
                     // performance is much by collecting more requests/commits before performing the poll.
@@ -251,7 +307,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                     {
                         SendFailure(ex, Sender);
                     }
-                    
+
                     return true;
 
 
@@ -348,7 +404,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                 }
 
                 // reply to outstanding requests is important if the actor is restarted
-                foreach (var (actorRef, request) in _requests.ToTuples())
+                foreach (var (actorRef, request) in _requests)
                 {
                     var emptyMessages = new KafkaConsumerActorMetadata.Internal.Messages<K, V>(request.RequestId,
                         ImmutableList<ConsumeResult<K, V>>.Empty);
@@ -524,10 +580,9 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
             var initialRebalanceInProcess = _rebalanceInProgress.Value;
 
             var partitionsToFetch = _requests.Values.SelectMany(v => v.Topics)
-                .Where(p => currentAssignment.Contains(p))
                 .ToImmutableHashSet();
 
-            if (partitionsToFetch.IsEmpty || _requests.IsEmpty())
+            if (_requests.IsEmpty())
             {
                 if (_settings.VerboseLogging)
                     _log.Debug("Requests are empty - attempting to consume.");
@@ -537,8 +592,6 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                     var consumed = _consumer.Consume(0);
                     if (consumed is not null)
                         throw new IllegalActorStateException("Consumed message should be null");
-                    PausePartitions(_pausedPartitions);
-                    _pausedPartitions = ImmutableList<TopicPartition>.Empty;
                 }
                 catch (Exception e)
                 {
@@ -546,7 +599,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                 }
             }
             else
-            {   
+            {
                 // resume partitions to fetch
                 var (resumeThese, pauseThese) = currentAssignment.Partition(partitionsToFetch.Contains);
                 PausePartitions(
@@ -556,6 +609,30 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                 using (var cts = new CancellationTokenSource(_settings.PollTimeout))
                 {
                     var (polled, exception) = PollKafka(cts.Token);
+                    var assignedAtEnd = _consumer.Assignment.ToImmutableHashSet();
+                    
+                    /*
+                     * Any partitions that were NOT ASSIGNED at the start of the poll BUT ARE ASSIGNED NOW
+                     * got assigned to us mid-poll then. We need to stash these messages until they are requested.
+                     */
+                    var newlyAssigned = assignedAtEnd.Except(currentAssignment);
+                    if (newlyAssigned.Any())
+                    {
+                        // now filter again to see if any of these newlyAssigned partitions have not been requested
+                        var newlyAssignedButNotRequested = newlyAssigned.Except(partitionsToFetch);
+                        if (newlyAssignedButNotRequested.Any())
+                        {
+                            var originalUnrequestedCount = _unRequestedMessages.Count;
+                            var (newUnrequested, requested) = polled.Partition(c => newlyAssignedButNotRequested.Contains(c.TopicPartition));
+                            _unRequestedMessages = _unRequestedMessages.AddRange(newUnrequested);
+                            var totalNewUnrequested = _unRequestedMessages.Count - originalUnrequestedCount;
+                            _log.Info("Stashing [{0}] messages for newly assigned but not requested partitions: {1} - [{2}] total unrequested messages",
+                               totalNewUnrequested,  string.Join(", ", newlyAssignedButNotRequested), _unRequestedMessages.Count);
+
+                            polled = requested;
+                        }
+                    }
+                    
                     try
                     {
                         ProcessResult(partitionsToFetch, polled);
@@ -579,7 +656,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
             }
         }
 
-        private (List<ConsumeResult<K, V>>, Exception?) PollKafka(CancellationToken token)
+        private (IReadOnlyCollection<ConsumeResult<K, V>>, Exception?) PollKafka(CancellationToken token)
         {
             var i = _settings.MaxPollRecords; // use the number of poll attempts specified in the settings
             var timeout = Math.Max((int)_pollTimeout.TotalMilliseconds / i, 1);
@@ -592,8 +669,6 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                     var consumed = _consumer.Consume(timeout);
                     if (consumed is null)
                     {
-                        PausePartitions(_pausedPartitions);
-                        _pausedPartitions = ImmutableList<TopicPartition>.Empty;
                         return (polled, null);
                     }
 
@@ -609,14 +684,15 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
             return (polled, null);
         }
 
-        private void ProcessResult(IImmutableSet<TopicPartition> partitionsToFetch, List<ConsumeResult<K, V>> rawResult)
+        private void ProcessResult(IImmutableSet<TopicPartition> partitionsToFetch, IReadOnlyCollection<ConsumeResult<K, V>> rawResult)
         {
             if (_log.IsDebugEnabled)
                 _log.Debug("Processing poll result with {0} records", rawResult.Count);
 
             if (rawResult.IsEmpty())
                 return;
-
+            
+            // TODO: remove after we verify the fix to https://github.com/akkadotnet/Akka.Streams.Kafka/issues/415
             var fetchedTps = rawResult.Select(m => m.TopicPartition).ToImmutableSet();
             if (!fetchedTps.Except(partitionsToFetch).IsEmpty())
                 throw new ArgumentException(

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
@@ -596,7 +596,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                          * Were that to happen, we need to stash the message for future processing.
                          */
                         _unRequestedMessages = _unRequestedMessages.Add(consumed);
-                        _log.Info("Received [1] message from unrequested partition: {0} - stashing for later processing. " +,
+                        _log.Info("Received [1] message from unrequested partition: {0} - stashing for later processing. " +
                                   "Total unrequested messages: {1}",
                             consumed.TopicPartition, _unRequestedMessages.Count);
                     }

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
@@ -78,7 +78,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
         /// While `true`, committing is delayed.
         /// Changed by `onPartitionsRevoked` and `onPartitionsAssigned` callbacks
         /// </summary>
-        private AtomicBoolean _rebalanceInProgress = new();
+        private bool _rebalanceInProgress = false;
 
         /// <summary>
         /// Keeps commit offsets during rebalances for later commit.
@@ -160,7 +160,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
             watch.Stop();
             CheckDuration(watch, "onAssign");
 
-            _rebalanceInProgress.GetAndSet(false);
+            _rebalanceInProgress = false;
         }
 
         // This is RebalanceListener.OnPartitionRevoked on JVM
@@ -177,7 +177,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
             CheckDuration(watch, "onRevoke");
 
             _commitRefreshing.Revoke(partitions.Select(tp => tp.TopicPartition).ToImmutableHashSet());
-            _rebalanceInProgress.GetAndSet(true);
+            _rebalanceInProgress = true;
         }
 
         // This is RebalanceListener.OnPartitionLost on JVM
@@ -200,7 +200,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
             CheckDuration(watch, "onLost");
 
             _commitRefreshing.Revoke(partitions.Select(tp => tp.TopicPartition).ToImmutableHashSet());
-            _rebalanceInProgress.GetAndSet(true);
+            _rebalanceInProgress = true;
         }
 
         private void RebalancePostStop()
@@ -577,7 +577,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
         private void Poll()
         {
             var currentAssignment = _consumer.Assignment.ToImmutableList();
-            var initialRebalanceInProcess = _rebalanceInProgress.Value;
+            var initialRebalanceInProcess = _rebalanceInProgress;
 
             var partitionsToFetch = _requests.Values.SelectMany(v => v.Topics)
                 .ToImmutableHashSet();
@@ -667,7 +667,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                 {
                     // this would return immediately if there are messages waiting inside the client queue buffer
                     var consumed = _consumer.Consume(timeout);
-                    if (consumed is null)
+                    if (consumed is null || _rebalanceInProgress) // bail out if we detect the start of a re-balance
                     {
                         return (polled, null);
                     }
@@ -786,7 +786,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
         /// </summary>
         private void CheckRebalanceState(bool initialRebalanceInProgress)
         {
-            if (initialRebalanceInProgress && !_rebalanceInProgress.Value && _rebalanceCommitSenders.Any())
+            if (initialRebalanceInProgress && !_rebalanceInProgress && _rebalanceCommitSenders.Any())
             {
                 _log.Debug(
                     $"Comitting stash {string.Join(", ", _rebalanceCommitStash)} replying to {string.Join(", ", _rebalanceCommitSenders)}");

--- a/src/Directory.Generated.props
+++ b/src/Directory.Generated.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.5.8</VersionPrefix>
-    <PackageReleaseNotes>[Upgraded to Akka.NET v1.5.8](https://github.com/akkadotnet/akka.net/releases/tag/1.5.8)</PackageReleaseNotes>
+    <VersionPrefix>1.5.38</VersionPrefix>
+    <PackageReleaseNotes>[Upgraded to Akka.NET v1.5.38](https://github.com/akkadotnet/akka.net/releases/tag/1.5.38)
+[Resolved: System.ArgumentException: Unexpected records polled potentially thrown during a rebalance](https://github.com/akkadotnet/Akka.Streams.Kafka/issues/415)</PackageReleaseNotes>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Changes

close #415 - this is fairly difficult to test in our test suite without having manual control over partition assignments, so the test lab might have better luck. I'll see what I can come up with. But in the meantime, check out my PR comments.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #415, #447

