### PR TITLE
Change `Assign` and `AssignWithOffsets` to use `IncrementalAssign`

### DIFF
--- a/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
@@ -391,8 +391,7 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                     case KafkaConsumerActorMetadata.Internal.Assign assign:
                     {
                         CheckOverlappingRequests("Assign", Sender, assign.TopicPartitions);
-                        var previousAssigned = _consumer.Assignment;
-                        _consumer.Assign(assign.TopicPartitions.Union(previousAssigned));
+                        _consumer.IncrementalAssign(assign.TopicPartitions);
                         _commitRefreshing.AssignedPositions(assign.TopicPartitions, _consumer,
                             _settings.PositionTimeout);
                         break;
@@ -403,10 +402,8 @@ namespace Akka.Streams.Kafka.Stages.Consumers.Actors
                         var topicPartitions = assignWithOffset.TopicPartitionOffsets.Select(o => o.TopicPartition)
                             .ToImmutableHashSet();
                         CheckOverlappingRequests("AssignWithOffset", Sender, topicPartitions);
-
-                        var previousAssigned = _consumer.Assignment
-                            .Select(c => new TopicPartitionOffset(c, Offset.Stored));
-                        _consumer.Assign(assignWithOffset.TopicPartitionOffsets.Union(previousAssigned));
+                        
+                        _consumer.IncrementalAssign(assignWithOffset.TopicPartitionOffsets);
                         _commitRefreshing.AssignedPositions(topicPartitions, assignWithOffset.TopicPartitionOffsets);
                         break;
                     }


### PR DESCRIPTION
## Changes

This should solve the issue of having to re-calculate offsets for being able to include new assignments

part of #447 

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
