### PR TITLE
Added v1.5.39-beta1 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,10 @@
-#### 1.5.38 March 4th 2025 ####
+#### 1.5.39-beta1 March 13th 2025 ####
 
-* [Upgraded to Akka.NET v1.5.38](https://github.com/akkadotnet/akka.net/releases/tag/1.5.38)
+*v1.5.39 is a major update for Akka.Streams.Kafka*
+
 * [Resolved: System.ArgumentException: Unexpected records polled potentially thrown during a rebalance](https://github.com/akkadotnet/Akka.Streams.Kafka/issues/415)
+* [Expose `ConsumerSettings.MaxPollRecords`](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/453) available so users can performance-tune how many records to fetch during polling.
+* [Change `Assign` and `AssignWithOffsets` to use `IncrementalAssign`](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/455) - prevents `Offset` resets for users running `ManualSubscription`s
+* [Refactor `SubSourceStageLogic`; filter messages from revoked partitions in partitioned stream sources](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/452)
+* [Filter out buffered records from recently revoked partitions](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/450)
+* [Enable nullability](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/449)

--- a/src/Directory.Generated.props
+++ b/src/Directory.Generated.props
@@ -1,7 +1,12 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.5.38</VersionPrefix>
-    <PackageReleaseNotes>[Upgraded to Akka.NET v1.5.38](https://github.com/akkadotnet/akka.net/releases/tag/1.5.38)
-[Resolved: System.ArgumentException: Unexpected records polled potentially thrown during a rebalance](https://github.com/akkadotnet/Akka.Streams.Kafka/issues/415)</PackageReleaseNotes>
+    <VersionPrefix>1.5.39</VersionPrefix>
+    <PackageReleaseNotes>v1.5.39 is a major update for Akka.Streams.Kafka*
+[Resolved: System.ArgumentException: Unexpected records polled potentially thrown during a rebalance](https://github.com/akkadotnet/Akka.Streams.Kafka/issues/415)
+[Expose `ConsumerSettings.MaxPollRecords`](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/453) available so users can performance-tune how many records to fetch during polling.
+[Change `Assign` and `AssignWithOffsets` to use `IncrementalAssign`](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/455) - prevents `Offset` resets for users running `ManualSubscription`s
+[Refactor `SubSourceStageLogic`; filter messages from revoked partitions in partitioned stream sources](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/452)
+[Filter out buffered records from recently revoked partitions](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/450)
+[Enable nullability](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/449)</PackageReleaseNotes>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
#### 1.5.39-beta1 March 13th 2025 ####

*v1.5.39 is a major update for Akka.Streams.Kafka*

* [Resolved: System.ArgumentException: Unexpected records polled potentially thrown during a rebalance](https://github.com/akkadotnet/Akka.Streams.Kafka/issues/415)
* [Expose `ConsumerSettings.MaxPollRecords`](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/453) available so users can performance-tune how many records to fetch during polling.
* [Change `Assign` and `AssignWithOffsets` to use `IncrementalAssign`](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/455) - prevents `Offset` resets for users running `ManualSubscription`s
* [Refactor `SubSourceStageLogic`; filter messages from revoked partitions in partitioned stream sources](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/452)
* [Filter out buffered records from recently revoked partitions](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/450)
* [Enable nullability](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/449)