### PR TITLE
quality: generate and publish CRAP scores to AzDo

### DIFF
--- a/build-system/azure-pipeline.template.yaml
+++ b/build-system/azure-pipeline.template.yaml
@@ -20,7 +20,7 @@ jobs:
       - script: dotnet build -c Release
         displayName: 'Build'
           
-      - script: dotnet test -c Release --no-build --logger:trx --collect:XPlat Code Coverage --results-directory TestResults
+      - script: dotnet test -c Release --no-build --logger:trx --collect:"XPlat Code Coverage" --results-directory TestResults
         displayName: 'Run tests'
         continueOnError: true # Allow continuation even if tests fail
           

--- a/build-system/azure-pipeline.template.yaml
+++ b/build-system/azure-pipeline.template.yaml
@@ -20,8 +20,9 @@ jobs:
       - script: dotnet build -c Release
         displayName: 'Build'
           
-      - script: dotnet test -c Release --no-build --logger:trx
+      - script: dotnet test -c Release --no-build --logger:trx --collect:XPlat Code Coverage --results-directory TestResults
         displayName: 'Run tests'
+        continueOnError: true # Allow continuation even if tests fail
           
       - task: PublishTestResults@2
         displayName: 'Publish test results'
@@ -30,7 +31,24 @@ jobs:
           testResultsFiles: '**/*.trx'
           testRunTitle: '${{ parameters.name }}'
           mergeTestResults: true
-        condition: succeededOrFailed()
+        condition: always() # Run this step regardless of previous step outcomes
+
+      - task: reportgenerator@5
+        displayName: ReportGenerator
+        condition: always() # Run this step regardless of previous step outcomes
+        continueOnError: true
+        inputs:
+          reports: '$(Build.SourcesDirectory)/TestResults/**/*.cobertura.xml'
+          targetdir: '$(Build.SourcesDirectory)/coveragereport'
+          reporttypes: 'HtmlInline_AzurePipelines;Cobertura;Badges'
+          assemblyfilters: '-xunit*'
+          publishCodeCoverageResults: true
+
+      - publish: $(Build.SourcesDirectory)/coveragereport
+        displayName: 'Publish Coverage Report'
+        condition: and(always(), eq(variables['Agent.OS'], 'Windows_NT'))
+        continueOnError: true
+        artifact: 'CoverageReports'
           
       - script: dotnet pack -c Release --no-build -o $(Build.ArtifactStagingDirectory)/nuget
         displayName: 'Create packages'

--- a/build-system/azure-pipeline.template.yaml
+++ b/build-system/azure-pipeline.template.yaml
@@ -59,3 +59,8 @@ jobs:
           PathtoPublish: '$(Build.ArtifactStagingDirectory)/nuget'
           ArtifactName: 'nuget'
           publishLocation: 'Container'
+
+      - script: 'echo 1>&2'
+        failOnStderr: true
+        displayName: 'If above is partially succeeded, then fail'
+        condition: eq(variables['Agent.JobStatus'], 'SucceededWithIssues')


### PR DESCRIPTION
## Changes

Use coverlet to generate code coverage reports containing CRAP scores et al and publish those to Azure DevOps on every PR run

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
