### PR TITLE
quality: exclude obsolete and non-essential code from coverage reports

### DIFF
--- a/build-system/azure-pipeline.template.yaml
+++ b/build-system/azure-pipeline.template.yaml
@@ -20,7 +20,7 @@ jobs:
       - script: dotnet build -c Release
         displayName: 'Build'
           
-      - script: dotnet test -c Release --no-build --logger:trx --collect:"XPlat Code Coverage" --results-directory TestResults
+      - script: dotnet test -c Release --no-build --logger:trx --collect:"XPlat Code Coverage" --results-directory TestResults --settings coverlet.runsettings
         displayName: 'Run tests'
         continueOnError: true # Allow continuation even if tests fail
           

--- a/coverlet.runsettings
+++ b/coverlet.runsettings
@@ -5,17 +5,20 @@
       <DataCollector friendlyName="XPlat code coverage">
         <Configuration>
           <Format>json,cobertura,lcov,teamcity,opencover</Format>
-          <Exclude>[*.Tests?]*,[*.Benchmarks?]*</Exclude> <!-- [Assembly-Filter] Type-Filter --> 
+          <Exclude>[*.Tests]*,[*.Benchmark]*</Exclude> <!-- [Assembly-Filter] Type-Filter --> 
           <!--<Include>[coverlet.*]*,[*]Coverlet.Core*</Include>--> <!-- [Assembly-Filter]Type-Filter -->
           <ExcludeByAttribute>Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute>
-          <ExcludeByFile>examples/*</ExcludeByFile> <!-- Globbing filter -->
-          <!--<IncludeDirectory>../dir1/,../dir2/,</IncludeDirectory>-->
+
+           <!-- FILE EXCLUSIONS -->
+          <ExcludeByFile>**/examples/**/*</ExcludeByFile> <!-- Recursive glob pattern -->
+
+          <!-- TEST ASSEMBLY SETTINGS -->
+          <IncludeTestAssembly>false</IncludeTestAssembly> <!-- Exclude test projects -->
+
+           <!-- OPTIMIZATION FLAGS -->
           <SingleHit>false</SingleHit>
           <UseSourceLink>true</UseSourceLink>
-          <IncludeTestAssembly>true</IncludeTestAssembly>
           <SkipAutoProps>true</SkipAutoProps>
-          <DeterministicReport>false</DeterministicReport>
-          <ExcludeAssembliesWithoutSources>MissingAll,MissingAny,None</ExcludeAssembliesWithoutSources>
         </Configuration>
       </DataCollector>
     </DataCollectors>

--- a/coverlet.runsettings
+++ b/coverlet.runsettings
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat code coverage">
+        <Configuration>
+          <Format>json,cobertura,lcov,teamcity,opencover</Format>
+          <Exclude>[*.Tests?]*,[*.Benchmarks?]*</Exclude> <!-- [Assembly-Filter] Type-Filter --> 
+          <!--<Include>[coverlet.*]*,[*]Coverlet.Core*</Include>--> <!-- [Assembly-Filter]Type-Filter -->
+          <ExcludeByAttribute>Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute>
+          <ExcludeByFile>examples/*</ExcludeByFile> <!-- Globbing filter -->
+          <!--<IncludeDirectory>../dir1/,../dir2/,</IncludeDirectory>-->
+          <SingleHit>false</SingleHit>
+          <UseSourceLink>true</UseSourceLink>
+          <IncludeTestAssembly>true</IncludeTestAssembly>
+          <SkipAutoProps>true</SkipAutoProps>
+          <DeterministicReport>false</DeterministicReport>
+          <ExcludeAssembliesWithoutSources>MissingAll,MissingAny,None</ExcludeAssembliesWithoutSources>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
## Changes

Leveraging some of the advice from https://github.com/coverlet-coverage/coverlet/blob/master/Documentation/VSTestIntegration.md to filter out `Obsolete` code, example code, benchmarks, and test assemblies from code coverage (i.e. we don't want to test our tests)

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
