### PR TITLE
Bump tests and example / benchmark runtime to .NET 9

### DIFF
--- a/Akka.Streams.Kafka.sln
+++ b/Akka.Streams.Kafka.sln
@@ -34,18 +34,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Streams.Kafka.Cpu.Benc
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Kafka.Partitioned.Consumer", "examples\Kafka.Partitioned.Consumer\Kafka.Partitioned.Consumer.csproj", "{EB6C9C63-DA66-44E6-938B-5CA0D3F4312E}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build-system", "build-system", "{CD594973-740C-425C-A2EF-4B764533A77A}"
-	ProjectSection(SolutionItems) = preProject
-		build-system\azure-pipeline.template.yaml = build-system\azure-pipeline.template.yaml
-		build-system\linux-pr-validation.yaml = build-system\linux-pr-validation.yaml
-		build-system\nightly-builds.yaml = build-system\nightly-builds.yaml
-		build-system\README.md = build-system\README.md
-		build-system\windows-pr-validation.yaml = build-system\windows-pr-validation.yaml
-		build-system\windows-release.yaml = build-system\windows-release.yaml
-		Directory.Build.props = Directory.Build.props
-		Directory.Packages.props = Directory.Packages.props
-	EndProjectSection
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -98,7 +86,6 @@ Global
 		{B428BB4E-5B31-47E2-A1CB-A85FBCE436F2} = {DBBF6380-3734-49B5-8BF6-74A7C33DFA55}
 		{9B4B5FBF-A46C-490E-8E19-72F577A1C31E} = {DBBF6380-3734-49B5-8BF6-74A7C33DFA55}
 		{EB6C9C63-DA66-44E6-938B-5CA0D3F4312E} = {DBBF6380-3734-49B5-8BF6-74A7C33DFA55}
-		{CD594973-740C-425C-A2EF-4B764533A77A} = {568F6963-99B1-4E1C-8394-52E4064D6F32}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4B399516-A19F-4B0E-9AA9-CD6197619BE0}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,10 +13,9 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Visual Studio C# settings -->
-    <NetFrameworkTestVersion>net472</NetFrameworkTestVersion>
     <NetStandardLibVersion>netstandard2.0</NetStandardLibVersion>
     <NetLibVersion>net6.0</NetLibVersion>
-    <NetCoreTestVersion>net6.0</NetCoreTestVersion>
+    <NetCoreTestVersion>net9.0</NetCoreTestVersion>
   </PropertyGroup>
   <ItemGroup>
     <Using Include="Akka.Event" />


### PR DESCRIPTION
.NET 6 isn't supported any more.