### PR TITLE
Migrated `ConnectionCheckerSettings` to use `record` types

### DIFF
--- a/src/Akka.Streams.Kafka/Internal/ConfigSettings.cs
+++ b/src/Akka.Streams.Kafka/Internal/ConfigSettings.cs
@@ -10,6 +10,9 @@ namespace Akka.Streams.Kafka.Internal
     {
         public static ImmutableDictionary<string, string> ParseKafkaClientsProperties(this Config config)
         {
+            var keys = CollectKeys(config.Root, [], config.Root.GetObject().Items.Keys.ToList());
+            return keys.ToDictionary(k => k, v => config.GetString(v)).ToImmutableDictionary();
+
             HashSet<string> CollectKeys(HoconValue c, HashSet<string> processedKeys, List<string> unprocessedKeys)
             {
                 while (true)
@@ -29,9 +32,6 @@ namespace Akka.Streams.Kafka.Internal
                     processedKeys.Add(currentKey);
                 }
             }
-
-            var keys = CollectKeys(config.Root, new HashSet<string>(), config.Root.GetObject().Items.Keys.ToList());
-            return keys.ToDictionary(k => k, v => config.GetString(v)).ToImmutableDictionary();
         }
     }
 }

--- a/src/Akka.Streams.Kafka/Internal/ConnectionChecker.cs
+++ b/src/Akka.Streams.Kafka/Internal/ConnectionChecker.cs
@@ -48,11 +48,11 @@ namespace Akka.Streams.Kafka.Internal
                         Context.Stop(Self);
                         return true;
 
-                    case Internal.CheckConnection _:
+                    case Internal.CheckConnection:
                         Context.Parent.Tell(Metadata.ListTopics.Instance);
                         return true;
 
-                    case Metadata.Topics topics when topics.Response.Failure.Value is TimeoutException:
+                    case Metadata.Topics { Response.Failure.Value: TimeoutException } topics:
                         // failedAttempts is a sum of first triggered failure and retries (retries + 1)
                         if (failedAttempts == _maxRetries)
                         {
@@ -67,11 +67,11 @@ namespace Akka.Streams.Kafka.Internal
                         return true;
 
                     // This is a debug, to check to see if C# Confluent.Kafka behaves differently compared to JVM
-                    case Metadata.Topics topics when topics.Response.Failure.HasValue:
+                    case Metadata.Topics { Response.Failure.HasValue: true } topics:
                         _log.Warning($"Caught an exception while testing broker connection: {topics.Response.Failure.Value}");
                         return false;
 
-                    case Metadata.Topics topics when topics.Response.IsSuccess:
+                    case Metadata.Topics { Response.IsSuccess: true }:
                         StartTimer();
                         Become(Regular());
                         return true;

--- a/src/Akka.Streams.Kafka/Settings/ConnectionCheckerSettings.cs
+++ b/src/Akka.Streams.Kafka/Settings/ConnectionCheckerSettings.cs
@@ -3,7 +3,7 @@ using Akka.Configuration;
 
 namespace Akka.Streams.Kafka.Settings
 {
-    public class ConnectionCheckerSettings
+    public sealed record ConnectionCheckerSettings
     {
         public const string ConfigPath = "connection-checker";
         public static readonly string FullConfigPath = $"{ConsumerSettings.ConfigPath}.{ConfigPath}";
@@ -14,9 +14,9 @@ namespace Akka.Streams.Kafka.Settings
         public static ConnectionCheckerSettings Create(int maxRetries, TimeSpan checkInterval, double factor)
             => new ConnectionCheckerSettings(true, maxRetries, checkInterval, factor);
 
-        public static ConnectionCheckerSettings Create(Config config)
+        public static ConnectionCheckerSettings Create(Config? config = null)
         {
-            if (config == default)
+            if (config == null)
                 return Disabled;
 
             return config.GetBoolean("enabled", false)
@@ -28,10 +28,10 @@ namespace Akka.Streams.Kafka.Settings
                 : Disabled;
         }
 
-        public bool Enabled { get; }
-        public int MaxRetries { get; }
-        public TimeSpan CheckInterval { get; }
-        public double Factor { get; }
+        public bool Enabled { get; init; }
+        public int MaxRetries { get; init; }
+        public TimeSpan CheckInterval { get; init; }
+        public double Factor { get; init; }
 
         internal ConnectionCheckerSettings(
             bool enabled, 
@@ -52,6 +52,7 @@ namespace Akka.Streams.Kafka.Settings
             Factor = factor;
         }
 
+        [Obsolete("Use record copy methods")]
         private ConnectionCheckerSettings Copy(
             bool? enabled = null,
             int? maxRetries = null,
@@ -64,16 +65,15 @@ namespace Akka.Streams.Kafka.Settings
                 factor: factor ?? Factor);
 
         public ConnectionCheckerSettings WithEnabled(bool enabled)
-            => Copy(enabled: enabled);
+            => this with { Enabled = enabled };
 
         public ConnectionCheckerSettings WithMaxRetries(int maxRetries)
-            => Copy(maxRetries: maxRetries);
-
+            => this with { MaxRetries = maxRetries };
         public ConnectionCheckerSettings WithFactor(double factor)
-            => Copy(factor: factor);
+            => this with { Factor = factor };
 
         public ConnectionCheckerSettings WithCheckInterval(TimeSpan checkInterval)
-            => Copy(checkInterval: checkInterval);
+            => this with { CheckInterval = checkInterval };
 
         public override string ToString() => $"Akka.Streams.Kafka.ConnectionCheckerSettings(Enabled={Enabled},MaxRetries={MaxRetries},CheckInterval={CheckInterval},Factor={Factor})";
     }


### PR DESCRIPTION
## Changes

Get rid of old `.Copy` methods where we can.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).