### PR TITLE
readjust all benchmarks to use just the default values

### DIFF
--- a/src/Akka.Streams.Kafka.Benchmark/Benchmarks/ComittablePartitionedSourceBenchmark.cs
+++ b/src/Akka.Streams.Kafka.Benchmark/Benchmarks/ComittablePartitionedSourceBenchmark.cs
@@ -14,9 +14,9 @@ namespace Akka.Streams.Kafka.Benchmark.Benchmarks;
 [Config(typeof(MacroBenchmarkConfig))]
 public class CommittablePartitionedSourceBenchmark : KafkaConsumerBenchmark<Offset>
 {
-    [Params(10, 100, 500)] public int PollBatchSize { get; set; }
+    [Params(500)] public int PollBatchSize { get; set; }
 
-    [Params(10)] public int CommitBatchSize { get; set; }
+    [Params(1000)] public int CommitBatchSize { get; set; }
 
 
     protected override Source<Offset, IControl> CreateSource()

--- a/src/Akka.Streams.Kafka.Benchmark/Benchmarks/CommittableSourceBenchmark.cs
+++ b/src/Akka.Streams.Kafka.Benchmark/Benchmarks/CommittableSourceBenchmark.cs
@@ -14,11 +14,9 @@ namespace Akka.Streams.Kafka.Benchmark.Benchmarks
     [Config(typeof(MacroBenchmarkConfig))]
     public class CommittableSourceBenchmark : KafkaConsumerBenchmark<Offset>
     {
-        [Params(10, 100, 500)]
-        public int PollBatchSize { get; set; }
-        
-        [Params(10, 100, 500)]
-        public int CommitBatchSize { get; set; }
+        [Params(500)] public int PollBatchSize { get; set; }
+
+        [Params(1000)] public int CommitBatchSize { get; set; }
 
         protected override Source<Offset, IControl> CreateSource()
         {

--- a/src/Akka.Streams.Kafka.Benchmark/Benchmarks/PlainConsumerBenchmark.cs
+++ b/src/Akka.Streams.Kafka.Benchmark/Benchmarks/PlainConsumerBenchmark.cs
@@ -13,7 +13,7 @@ namespace Akka.Streams.Kafka.Benchmark.Benchmarks
     [Config(typeof(MacroBenchmarkConfig))]
     public class PlainSourceBenchmark : KafkaConsumerBenchmark<ConsumeResult<Null, string>>
     {
-        [Params(10, 100, 500)]
+        [Params(500)]
         public int PollBatchSize { get; set; }
         
         protected override Source<ConsumeResult<Null, string>, IControl> CreateSource()

--- a/src/Akka.Streams.Kafka.Benchmark/Benchmarks/PlainPartitionedConsumerBenchmark.cs
+++ b/src/Akka.Streams.Kafka.Benchmark/Benchmarks/PlainPartitionedConsumerBenchmark.cs
@@ -13,7 +13,7 @@ namespace Akka.Streams.Kafka.Benchmark.Benchmarks;
 [Config(typeof(MacroBenchmarkConfig))]
 public class PlainPartitionedSourceBenchmark : KafkaConsumerBenchmark<ConsumeResult<Null, string>>
 {
-    [Params(10, 100, 500)] public int PollBatchSize { get; set; }
+    [Params(500)] public int PollBatchSize { get; set; }
 
     protected override Source<ConsumeResult<Null, string>, IControl> CreateSource()
     {


### PR DESCRIPTION
using the same values as https://github.com/akkadotnet/Akka.Streams.Kafka/pull/472