### PR TITLE
Added v1.5.39 release notes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,8 +8,56 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <VersionPrefix>1.5.39</VersionPrefix>
-    <PackageReleaseNotes>[Upgraded to Akka.NET v1.5.39](https://github.com/akkadotnet/akka.net/releases/tag/1.5.39)
-[Resolved: Kafka Producer - Exception occured inside SelectAsync - Cancellation cause must not be null](https://github.com/akkadotnet/Akka.Streams.Kafka/issues/426)</PackageReleaseNotes>
+    <PackageReleaseNotes>Akka.Streams.Kafka 1.5.39 represents a major improvement in stability and performance for Kafka stream processing, particularly for applications using manual partition assignment and rebalancing scenarios. This release includes critical fixes for partition management and introduces new performance tuning capabilities that give users more control over their Kafka consumer behavior.
+
+**Key Improvements**
+
+* Improved stability during partition rebalancing operations
+* Enhanced manual partition assignment behavior
+* Significantly more reliable and improved committing performance
+* New performance tuning capabilities for consumer polling
+* Better handling of partition revocation scenarios
+* Improved memory efficiency through C# record types
+
+**Breaking Changes**
+* Manual partition assignment now uses `IncrementalAssign` instead of `Assign` - this prevents offset resets for users running `ManualSubscription`s. If you're using manual partition assignment, you'll need to verify your offset management logic is compatible with incremental assignment behavior.
+* Several internal types have been converted from classes to C# `record`s for better performance and nullability support. This change should be transparent for most users as records are fully compatible with standard class usage patterns. The only potential impact would be if you're using inheritance on these types (which is not a recommended pattern for Akka.Streams.Kafka types).
+* We removed some extension methods that should have never been made `public` in the first place.
+* We made some changes to `ICommittable` interface and others.
+
+**Major Bug Fixes and Improvements**
+* [Fixed critical issue: Exception inside SelectAsync with null cancellation cause](https://github.com/akkadotnet/Akka.Streams.Kafka/issues/426)
+* [Resolved: System.ArgumentException during rebalance operations](https://github.com/akkadotnet/Akka.Streams.Kafka/issues/415)
+* [Added performance tuning capability through ConsumerSettings.MaxPollRecords](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/453)
+* [Improved partition management: filtering messages from revoked partitions](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/452)
+* [Enhanced stability: filtering out buffered records from recently revoked partitions](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/450)
+
+**Performance Data**
+
+For the `PlainSource`:
+
+```                                                                                  
+                                                                                     
+BenchmarkDotNet v0.14.0, Pop!_OS 22.04 LTS                                           
+13th Gen Intel Core i7-1360P, 1 CPU, 16 logical and 12 physical cores                
+.NET SDK 9.0.100                                                                     
+  [Host]  : .NET 9.0.0 (9.0.24.52809), X64 RyuJIT AVX2                               
+  LongRun : .NET 9.0.0 (9.0.24.52809), X64 RyuJIT AVX2                               
+                                                                                     
+Job=LongRun  EvaluateOverhead=False  Concurrent=True                                 
+Server=True  InvocationCount=1  IterationCount=10                                    
+LaunchCount=3  RunStrategy=Monitoring  UnrollFactor=1                                
+WarmupCount=3  Categories=MacroBenchmark,Consumer,Plain                              
+                                                                                     
+```                                                                                  
+| Method              | PollBatchSize | Mean     | Error    | StdDev   | msg/sec   | 
+|-------------------- |-------------- |---------:|---------:|---------:|----------:| 
+| ConsumeMessageAsync | 500           | 41.29 Î¼s | 1.960 Î¼s | 2.933 Î¼s | 24,217.30 | 
+
+This is a ~2.5x improvement over what v1.5.38 was able to achieve.
+
+**Dependencies**
+* [Upgraded to Akka.NET v1.5.39](https://github.com/akkadotnet/akka.net/releases/tag/1.5.39)</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Visual Studio C# settings -->

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,56 @@
+#### 1.5.39 March 14th 2025 ####
+
+Akka.Streams.Kafka 1.5.39 represents a major improvement in stability and performance for Kafka stream processing, particularly for applications using manual partition assignment and rebalancing scenarios. This release includes critical fixes for partition management and introduces new performance tuning capabilities that give users more control over their Kafka consumer behavior.
+
+**Key Improvements**
+
+* Improved stability during partition rebalancing operations
+* Enhanced manual partition assignment behavior
+* Significantly more reliable and improved committing performance
+* New performance tuning capabilities for consumer polling
+* Better handling of partition revocation scenarios
+* Improved memory efficiency through C# record types
+
+**Breaking Changes**
+* Manual partition assignment now uses `IncrementalAssign` instead of `Assign` - this prevents offset resets for users running `ManualSubscription`s. If you're using manual partition assignment, you'll need to verify your offset management logic is compatible with incremental assignment behavior.
+* Several internal types have been converted from classes to C# `record`s for better performance and nullability support. This change should be transparent for most users as records are fully compatible with standard class usage patterns. The only potential impact would be if you're using inheritance on these types (which is not a recommended pattern for Akka.Streams.Kafka types).
+* We removed some extension methods that should have never been made `public` in the first place.
+* We made some changes to `ICommittable` interface and others.
+
+**Major Bug Fixes and Improvements**
+* [Fixed critical issue: Exception inside SelectAsync with null cancellation cause](https://github.com/akkadotnet/Akka.Streams.Kafka/issues/426)
+* [Resolved: System.ArgumentException during rebalance operations](https://github.com/akkadotnet/Akka.Streams.Kafka/issues/415)
+* [Added performance tuning capability through ConsumerSettings.MaxPollRecords](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/453)
+* [Improved partition management: filtering messages from revoked partitions](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/452)
+* [Enhanced stability: filtering out buffered records from recently revoked partitions](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/450)
+
+**Performance Data**
+
+For the `PlainSource`:
+
+```                                                                                  
+                                                                                     
+BenchmarkDotNet v0.14.0, Pop!_OS 22.04 LTS                                           
+13th Gen Intel Core i7-1360P, 1 CPU, 16 logical and 12 physical cores                
+.NET SDK 9.0.100                                                                     
+  [Host]  : .NET 9.0.0 (9.0.24.52809), X64 RyuJIT AVX2                               
+  LongRun : .NET 9.0.0 (9.0.24.52809), X64 RyuJIT AVX2                               
+                                                                                     
+Job=LongRun  EvaluateOverhead=False  Concurrent=True                                 
+Server=True  InvocationCount=1  IterationCount=10                                    
+LaunchCount=3  RunStrategy=Monitoring  UnrollFactor=1                                
+WarmupCount=3  Categories=MacroBenchmark,Consumer,Plain                              
+                                                                                     
+```                                                                                  
+| Method              | PollBatchSize | Mean     | Error    | StdDev   | msg/sec   | 
+|-------------------- |-------------- |---------:|---------:|---------:|----------:| 
+| ConsumeMessageAsync | 500           | 41.29 μs | 1.960 μs | 2.933 μs | 24,217.30 | 
+
+This is a ~2.5x improvement over what v1.5.38 was able to achieve.
+
+**Dependencies**
+* [Upgraded to Akka.NET v1.5.39](https://github.com/akkadotnet/akka.net/releases/tag/1.5.39)
+
 #### 1.5.39-beta2 March 14th 2025 ####
 
 * [Upgraded to Akka.NET v1.5.39](https://github.com/akkadotnet/akka.net/releases/tag/1.5.39)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-#### 1.5.39 March 14th 2025 ####
+#### 1.5.39 March 19th 2025 ####
 
 Akka.Streams.Kafka 1.5.39 represents a major improvement in stability and performance for Kafka stream processing, particularly for applications using manual partition assignment and rebalancing scenarios. This release includes critical fixes for partition management and introduces new performance tuning capabilities that give users more control over their Kafka consumer behavior.
 


### PR DESCRIPTION
#### 1.5.39 March 19th 2025 ####

Akka.Streams.Kafka 1.5.39 represents a major improvement in stability and performance for Kafka stream processing, particularly for applications using manual partition assignment and rebalancing scenarios. This release includes critical fixes for partition management and introduces new performance tuning capabilities that give users more control over their Kafka consumer behavior.

**Key Improvements**

* Improved stability during partition rebalancing operations
* Enhanced manual partition assignment behavior
* Significantly more reliable and improved committing performance
* New performance tuning capabilities for consumer polling
* Better handling of partition revocation scenarios
* Improved memory efficiency through C# record types

**Breaking Changes**
* Manual partition assignment now uses `IncrementalAssign` instead of `Assign` - this prevents offset resets for users running `ManualSubscription`s. If you're using manual partition assignment, you'll need to verify your offset management logic is compatible with incremental assignment behavior.
* Several internal types have been converted from classes to C# `record`s for better performance and nullability support. This change should be transparent for most users as records are fully compatible with standard class usage patterns. The only potential impact would be if you're using inheritance on these types (which is not a recommended pattern for Akka.Streams.Kafka types).
* We removed some extension methods that should have never been made `public` in the first place.
* We made some changes to `ICommittable` interface and others.

**Major Bug Fixes and Improvements**
* [Fixed critical issue: Exception inside SelectAsync with null cancellation cause](https://github.com/akkadotnet/Akka.Streams.Kafka/issues/426)
* [Resolved: System.ArgumentException during rebalance operations](https://github.com/akkadotnet/Akka.Streams.Kafka/issues/415)
* [Added performance tuning capability through ConsumerSettings.MaxPollRecords](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/453)
* [Improved partition management: filtering messages from revoked partitions](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/452)
* [Enhanced stability: filtering out buffered records from recently revoked partitions](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/450)

**Performance Data**

For the `PlainSource`:

```                                                                                  
                                                                                     
BenchmarkDotNet v0.14.0, Pop!_OS 22.04 LTS                                           
13th Gen Intel Core i7-1360P, 1 CPU, 16 logical and 12 physical cores                
.NET SDK 9.0.100                                                                     
  [Host]  : .NET 9.0.0 (9.0.24.52809), X64 RyuJIT AVX2                               
  LongRun : .NET 9.0.0 (9.0.24.52809), X64 RyuJIT AVX2                               
                                                                                     
Job=LongRun  EvaluateOverhead=False  Concurrent=True                                 
Server=True  InvocationCount=1  IterationCount=10                                    
LaunchCount=3  RunStrategy=Monitoring  UnrollFactor=1                                
WarmupCount=3  Categories=MacroBenchmark,Consumer,Plain                              
                                                                                     
```                                                                                  
| Method              | PollBatchSize | Mean     | Error    | StdDev   | msg/sec   | 
|-------------------- |-------------- |---------:|---------:|---------:|----------:| 
| ConsumeMessageAsync | 500           | 41.29 μs | 1.960 μs | 2.933 μs | 24,217.30 | 

This is a ~2.5x improvement over what v1.5.38 was able to achieve.

**Dependencies**
* [Upgraded to Akka.NET v1.5.39](https://github.com/akkadotnet/akka.net/releases/tag/1.5.39)