### PR TITLE
Committing: fix N+1 issues in `CommittableOffsetBatch`

### DIFF
--- a/Akka.Streams.Kafka.sln.DotSettings
+++ b/Akka.Streams.Kafka.sln.DotSettings
@@ -68,4 +68,5 @@
  &lt;copyright file="${File.FileName}" company="Akka.NET Project"&gt;
      Copyright (C) ${File.CreatedYear} - ${CurrentDate.Year} .NET Foundation &lt;https://github.com/akkadotnet/akka.net&gt;
 &lt;/copyright&gt;
------------------------------------------------------------------------</s:String></wpf:ResourceDictionary>
+-----------------------------------------------------------------------</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002ECodeCleanup_002EFileHeader_002EFileHeaderSettingsMigrate/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Akka.Streams.Kafka.Tests/BugFix240SupervisionStrategy.cs
+++ b/src/Akka.Streams.Kafka.Tests/BugFix240SupervisionStrategy.cs
@@ -281,12 +281,6 @@ public class BugFix240SupervisionStrategy : KafkaIntegrationTests
         var committedTopicPartition = new TopicPartition($"{topic}-done", 0);
         var callCount = 0;
 
-        Directive Decider(Exception cause)
-        {
-            callCount++;
-            return Directive.Resume;
-        }
-
         var committerSettings = CommitterSettings.Create(Sys);
         var consumerSettings = CreateConsumerSettings<string>(group);
         var counter = 0;
@@ -321,7 +315,7 @@ public class BugFix240SupervisionStrategy : KafkaIntegrationTests
                 t.CommitableOffset))
             .Via(KafkaProducer.FlexiFlow<Null, string, ICommittableOffset>(ProducerSettings))
             .WithAttributes(Attributes.CreateName("FlexiFlow"))
-            .Select(m => (ICommittable)m.PassThrough)
+            .Select(ICommittable (m) => m.PassThrough)
             .AlsoToMaterialized(Committer.Sink(committerSettings), DrainingControl<NotUsed>.Create)
             .To(Flow.Create<ICommittable>()
                 .Async()
@@ -348,7 +342,7 @@ public class BugFix240SupervisionStrategy : KafkaIntegrationTests
         var messages = new List<string>();
         for (var i = 0; i < 9; ++i)
         {
-            var message = probe.RequestNext();
+            var message = await probe.RequestNextAsync();
             messages.Add(message);
         }
 
@@ -356,6 +350,13 @@ public class BugFix240SupervisionStrategy : KafkaIntegrationTests
         // ignore it in the decider
         messages.Should().BeEquivalentTo(new[] { "1", "2", "3", "4", "6", "7", "8", "9", "10" });
         probe.Cancel();
+        return;
+
+        Directive Decider(Exception cause)
+        {
+            callCount++;
+            return Directive.Resume;
+        }
     }
 
     // Test that an error that happened internally inside the PlainSink stage should be handled
@@ -364,18 +365,6 @@ public class BugFix240SupervisionStrategy : KafkaIntegrationTests
     public async Task SupervisionStrategy_Decider_on_PlainSink_should_work()
     {
         var callCount = 0;
-
-        Directive Decider(Exception cause)
-        {
-            callCount++;
-            switch (cause)
-            {
-                case ProduceException<Null, string> ex when ex.Error.IsSerializationError():
-                    return Directive.Resume;
-                default:
-                    return Directive.Stop;
-            }
-        }
 
         var topic1 = CreateTopic(1);
         var group1 = CreateGroup(1);
@@ -387,7 +376,7 @@ public class BugFix240SupervisionStrategy : KafkaIntegrationTests
         // Exception is injected into the sink by the FailingSerializer serializer, it throws an exceptions
         // when the message "5" is encountered.
         var sourceTask = Source
-            .From(new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 })
+            .From([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
             .Select(elem => new ProducerRecord<Null, string>(new TopicPartition(topic1, 0), elem.ToString()))
             .RunWith(
                 KafkaProducer.PlainSink(producerSettings)
@@ -405,12 +394,25 @@ public class BugFix240SupervisionStrategy : KafkaIntegrationTests
         probe.Request(10);
         for (var i = 0; i < 9; i++)
         {
-            var message = probe.ExpectNext();
+            var message = await probe.ExpectNextAsync();
             Log.Info($"> [{i}]: {message}");
         }
 
         callCount.Should().Be(1);
         probe.Cancel();
+        return;
+
+        Directive Decider(Exception cause)
+        {
+            callCount++;
+            switch (cause)
+            {
+                case ProduceException<Null, string> ex when ex.Error.IsSerializationError():
+                    return Directive.Resume;
+                default:
+                    return Directive.Stop;
+            }
+        }
     }
 
     // Test that the default decider can be overridden with custom decider.
@@ -429,7 +431,7 @@ public class BugFix240SupervisionStrategy : KafkaIntegrationTests
         // Exception is injected into the sink by the FailingSerializer serializer, it throws an exceptions
         // when the message "5" is encountered.
         var sourceTask = Source
-            .From(new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 })
+            .From([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
             .Select(elem => new ProducerRecord<Null, string>(new TopicPartition(topic1, 0), elem.ToString()))
             .RunWith(
                 KafkaProducer.PlainSink(producerSettings)
@@ -447,7 +449,7 @@ public class BugFix240SupervisionStrategy : KafkaIntegrationTests
         probe.Request(10);
         for (var i = 0; i < 9; i++)
         {
-            var message = probe.ExpectNext();
+            var message = await probe.ExpectNextAsync();
             Log.Info($"> [{i}]: {message}");
         }
 
@@ -461,17 +463,6 @@ public class BugFix240SupervisionStrategy : KafkaIntegrationTests
     public async Task SupervisionStrategy_Decider_on_PlainSource_should_work()
     {
         var callCount = 0;
-
-        Directive Decider(Exception cause)
-        {
-            callCount++;
-            if (cause is ConsumeException ex && ex.Error.IsSerializationError())
-            {
-                return Directive.Resume;
-            }
-
-            return Directive.Stop;
-        }
 
         var elementsCount = 10;
         var topic1 = CreateTopic(1);
@@ -495,6 +486,18 @@ public class BugFix240SupervisionStrategy : KafkaIntegrationTests
         // this is twice elementCount because Decider is called twice on each exceptions
         callCount.Should().Be(elementsCount * 2);
         probe.Cancel();
+        return;
+
+        Directive Decider(Exception cause)
+        {
+            callCount++;
+            if (cause is ConsumeException ex && ex.Error.IsSerializationError())
+            {
+                return Directive.Resume;
+            }
+
+            return Directive.Stop;
+        }
     }
 
     // Test that the default decider can be overridden with custom decider.
@@ -590,7 +593,7 @@ public class BugFix240SupervisionStrategy : KafkaIntegrationTests
             if (completedTask == timeoutTask)
                 throw new TimeoutException($"Task exceeds timeout duration {timeout}");
             else
-                cts.Cancel();
+                await cts.CancelAsync();
         }
         finally
         {

--- a/src/Akka.Streams.Kafka.Tests/BugFix240SupervisionStrategy.cs
+++ b/src/Akka.Streams.Kafka.Tests/BugFix240SupervisionStrategy.cs
@@ -219,7 +219,7 @@ public class BugFix240SupervisionStrategy : KafkaIntegrationTests
                 Subscriptions.AssignmentWithOffset(new TopicPartitionOffset(topicPartition, Offset.Beginning)))
             .Select(c =>
             {
-                if (++count == 7)
+                if (++count == 6)
                     throw new Exception("BOOM!");
                 return c;
             })
@@ -230,7 +230,7 @@ public class BugFix240SupervisionStrategy : KafkaIntegrationTests
 
         var offsets = new List<string>();
         await probe.RequestAsync(11);
-        offsets.AddRange(await probe.ExpectNextNAsync(6)
+        offsets.AddRange(await probe.ExpectNextNAsync(5) // we always commit 1 element ahead
             .ToListAsync()); // we get an extra element here even though the offset is not committed
 
         // stream fails at index 7

--- a/src/Akka.Streams.Kafka.Tests/Integration/CommittingSpec.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/CommittingSpec.cs
@@ -328,8 +328,14 @@ public class CommittingSpec : KafkaIntegrationTests
             ConsumeAndBatchCommit(string t)
         {
             return KafkaConsumer.CommittableSource(consumerSettings, Subscriptions.Topics(t))
-                .Select(ICommittable (c) => c.CommitableOffset)
-                .Via(Committer.BatchFlow(CommitterSettings.Create(Sys).WithMaxBatch(10)))
+                .Select(c => c.CommitableOffset)
+                .Batch(10, CommittableOffsetBatch.Create, (s, o) => s.Updated(o))
+                .SelectAsync(1, async c =>
+                {
+                    var b = (CommittableOffsetBatch)c;
+                    await b.Commit();
+                    return c;
+                })
                 .ToMaterialized(this.SinkProbe<ICommittableOffsetBatch>(), Keep.Both)
                 .Run(Sys);
         }

--- a/src/Akka.Streams.Kafka.Tests/Integration/CommittingSpec.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/CommittingSpec.cs
@@ -29,7 +29,6 @@ public class CommittingSpec : KafkaIntegrationTests
     }
 
     private static readonly string[] Numbers = Enumerable.Range(1, 200).Select(c => c.ToString()).ToArray();
-    private const int Partition1 = 1;
 
     [Fact]
     public async Task CommittingMustEnsureUncommittedMessagesAreRedelivered()

--- a/src/Akka.Streams.Kafka.Tests/Integration/CommittingSpec.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/CommittingSpec.cs
@@ -299,4 +299,47 @@ public class CommittingSpec : KafkaIntegrationTests
         await probe1.CancelAsync();
         await control.IsShutdown;
     }
+
+    [Fact]
+    public async Task CommittingMustWorkInBatches()
+    {
+        var topic = CreateTopic(1);
+        var group = CreateGroup(1);
+        
+        await ProduceStrings(new TopicPartition(topic, new Partition(0)), Numbers.Take(100), ProducerSettings);
+
+        var consumerSettings = CreateConsumerSettings<Null, string>(group);
+
+        var (control, probe) = ConsumeAndBatchCommit(topic);
+        
+        // Request one batch
+        await probe.AsyncBuilder().Request(1).ExpectNextNAsync(1).ToListAsync();
+
+        await probe.CancelAsync();
+        await control.IsShutdown.WaitAsync(RemainingOrDefault);
+
+        var element = await ConsumeFirstElementAsync(topic, consumerSettings);
+        var i = int.Parse(element);
+        Assert.True(i > 1, "Should start after the first element");
+        
+        return;
+
+        (IControl control, TestSubscriber.Probe<ICommittableOffsetBatch> probe)
+            ConsumeAndBatchCommit(string t)
+        {
+            return KafkaConsumer.CommittableSource(consumerSettings, Subscriptions.Topics(t))
+                .Select(ICommittable (c) => c.CommitableOffset)
+                .Via(Committer.BatchFlow(CommitterSettings.Create(Sys).WithMaxBatch(10)))
+                .ToMaterialized(this.SinkProbe<ICommittableOffsetBatch>(), Keep.Both)
+                .Run(Sys);
+        }
+    }
+
+    private async Task<string> ConsumeFirstElementAsync(string topic, ConsumerSettings<Null, string> consumerSettings)
+    {
+        var (_, probe2) = CreateProbe(consumerSettings, topic);
+        var element = await probe2.AsyncBuilder().Request(1).ExpectNextAsync(TimeSpan.FromSeconds(60));
+        await probe2.CancelAsync();
+        return element;
+    }
 }

--- a/src/Akka.Streams.Kafka.Tests/Integration/CommittingSpec.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/CommittingSpec.cs
@@ -335,6 +335,45 @@ public class CommittingSpec : KafkaIntegrationTests
         }
     }
 
+    [Fact]
+    public async Task CommittingMustWorkWithCommitterSink()
+    {
+        var topic = CreateTopic(1);
+        var group = CreateGroup(1);
+        
+        await ProduceStrings(new TopicPartition(topic, new Partition(0)), Numbers.Take(100), ProducerSettings);
+
+        var consumerSettings = CreateConsumerSettings<Null, string>(group);
+        var committerSettings = CommitterSettings.Create(Sys).WithMaxBatch(5);
+
+        // Consume and fail in the middle of the commit batch
+        const int failAt1 = 32;
+
+        await Assert.ThrowsAsync<Exception>(async () =>
+        {
+            await ConsumeAndCommitUntil(topic, failAt1.ToString());
+        });
+
+        var element1 = await ConsumeFirstElementAsync(topic, consumerSettings);
+        var i = int.Parse(element1);
+        Assert.True(i >= failAt1 - committerSettings.MaxBatch, "Should re-process at most maxBatch elements");
+        return;
+
+        Task<Done> ConsumeAndCommitUntil(string t, string failAt)
+        {
+            return KafkaConsumer.CommittableSource(consumerSettings, Subscriptions.Topics(t))
+                .Select(c =>
+                {
+                    if (c.Record.Message.Value.Equals(failAt))
+                        throw new Exception();
+                    return c;
+                })
+                .Select(ICommittable (c) => c.CommitableOffset)
+                .ToMaterialized(Committer.Sink(committerSettings), Keep.Right)
+                .Run(Sys);
+        }
+    }
+
     private async Task<string> ConsumeFirstElementAsync(string topic, ConsumerSettings<Null, string> consumerSettings)
     {
         var (_, probe2) = CreateProbe(consumerSettings, topic);

--- a/src/Akka.Streams.Kafka.Tests/Integration/CommittingSpec.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/CommittingSpec.cs
@@ -380,6 +380,47 @@ public class CommittingSpec : KafkaIntegrationTests
         }
     }
 
+    [Fact]
+    public async Task CommittingMustWorkWithCommitterBatchFlowEvenWithUpstreamFailure()
+    { 
+        var topic = CreateTopic(1);
+        var group = CreateGroup(1);
+        
+        await ProduceStrings(new TopicPartition(topic, new Partition(0)), Numbers.Take(100), ProducerSettings);
+
+        var consumerSettings = CreateConsumerSettings<Null, string>(group);
+        var committerSettings = CommitterSettings.Create(Sys).WithMaxBatch(5);
+
+        // Consume and fail in the middle of the commit batch
+        const int failAt1 = 32;
+
+        await Assert.ThrowsAsync<Exception>(async () =>
+        {
+            await ConsumeAndCommitUntil(topic, failAt1.ToString());
+        });
+
+        var element1 = await ConsumeFirstElementAsync(topic, consumerSettings);
+        var i = int.Parse(element1);
+        Assert.True(i >= failAt1 - committerSettings.MaxBatch, "Should re-process at most maxBatch elements");
+        return;
+
+        Task<Done> ConsumeAndCommitUntil(string t, string failAt)
+        {
+            return KafkaConsumer.CommittableSource(consumerSettings, Subscriptions.Topics(t))
+                .Select(c =>
+                {
+                    if (c.Record.Message.Value.Equals(failAt))
+                        throw new Exception();
+                    return c;
+                })
+                .Select(ICommittable (c) => c.CommitableOffset)
+                .Via(Committer.BatchFlow(committerSettings))
+                .ToMaterialized(Sink.Ignore<ICommittableOffsetBatch>(), Keep.Right)
+                .Run(Sys);
+        }
+        
+    }
+
     private async Task<string> ConsumeFirstElementAsync(string topic, ConsumerSettings<Null, string> consumerSettings)
     {
         var (_, probe2) = CreateProbe(consumerSettings, topic);

--- a/src/Akka.Streams.Kafka.Tests/Internal/CommitCollectorStageSpecs.cs
+++ b/src/Akka.Streams.Kafka.Tests/Internal/CommitCollectorStageSpecs.cs
@@ -486,7 +486,9 @@ public class TestBatchCommitter
 
         public override Task CommitOneOfMany(TopicPartition topicPartition, OffsetAndMetadata offsetAndMetadata)
         {
-            var commitOffset = offsetAndMetadata.Offset;
+            // CommittableOffsetBatch.OffsetsAndMetadata points the next committed message.
+            // So to get committed message offset we need to subtract 1
+            var commitOffset = offsetAndMetadata.Offset - 1;
             var commit = new TopicPartitionOffset(topicPartition, commitOffset);
             _committer.Commits = _committer.Commits.Add(commit);
             return _committer.CompleteCommit();

--- a/src/Akka.Streams.Kafka.Tests/Internal/CommitCollectorStageSpecs.cs
+++ b/src/Akka.Streams.Kafka.Tests/Internal/CommitCollectorStageSpecs.cs
@@ -305,6 +305,7 @@ public class CommitCollectorStageSpecs : Akka.TestKit.Xunit2.TestKit
     {
         var settings = DefaultCommitterSettings.WithMaxBatch(1).WithCommitWhen(CommitWhen.NextOffsetObserved.Instance);
         var (sourceProbe, control, sinkProbe, offsetFactory) = StreamProbesWithOffsetFactory(settings);
+        
         // create batches of size 1
         var (batch1, msg2, batch3) = (offsetFactory.MakeBatch(), offsetFactory.MakeOffset(), offsetFactory.MakeBatch());
 

--- a/src/Akka.Streams.Kafka.Tests/Internal/CommitCollectorStageSpecs.cs
+++ b/src/Akka.Streams.Kafka.Tests/Internal/CommitCollectorStageSpecs.cs
@@ -68,7 +68,7 @@ public class CommitCollectorStageSpecs : Akka.TestKit.Xunit2.TestKit
 
         committedBatch.BatchSize.Should().Be(2);
         committedBatch.Offsets.Count.Should().Be(1); // 1 offset value per partition
-        committedBatch.Offsets.Last().Offset.Should().Be(msg2.Offset.Offset);
+        committedBatch.Offsets.Values.Last().Should().Be(msg2.Offset.Offset);
         offsetFactory.Committer.Commits.Count.Should().Be(1, "expected only one batch commit");
 
         await control.Shutdown().WaitAsync(RemainingOrDefault);
@@ -89,7 +89,7 @@ public class CommitCollectorStageSpecs : Akka.TestKit.Xunit2.TestKit
         var committedBatch = await sinkProbe.ExpectNextAsync();
         committedBatch.BatchSize.Should().Be(1);
         committedBatch.Offsets.Count.Should().Be(1); // 1 offset value per partition
-        committedBatch.Offsets.Last().Offset.Should().Be(msg.Offset.Offset);
+        committedBatch.Offsets.Values.Last().Should().Be(msg.Offset.Offset);
         offsetFactory.Committer.Commits.Count.Should().Be(1, "expected only one batch commit");
 
         await control.Shutdown().WaitAsync(RemainingOrDefault);
@@ -115,7 +115,7 @@ public class CommitCollectorStageSpecs : Akka.TestKit.Xunit2.TestKit
 
         committedBatch.BatchSize.Should().Be(1);
         committedBatch.Offsets.Count.Should().Be(1); // 1 offset value per partition
-        committedBatch.Offsets.Last().Offset.Should().Be(msg.Offset.Offset);
+        committedBatch.Offsets.Values.Last().Should().Be(msg.Offset.Offset);
         offsetFactory.Committer.Commits.Count.Should().Be(1, "expected only one batch commit");
 
         await control.Shutdown().WaitAsync(RemainingOrDefault);
@@ -143,11 +143,11 @@ public class CommitCollectorStageSpecs : Akka.TestKit.Xunit2.TestKit
 
         committedBatch.BatchSize.Should().Be(1);
         committedBatch.Offsets.Count.Should().Be(1); // 1 offset value per partition
-        committedBatch.Offsets.Last().Offset.Should().Be(msg1.Offset.Offset);
+        committedBatch.Offsets.Values.Last().Should().Be(msg1.Offset.Offset);
 
         committedBatch2.BatchSize.Should().Be(2);
         committedBatch2.Offsets.Count.Should().Be(1); // 1 offset value per partition
-        committedBatch2.Offsets.Last().Offset.Should().Be(msg3.Offset.Offset);
+        committedBatch2.Offsets.Values.Last().Should().Be(msg3.Offset.Offset);
 
         await control.Shutdown().WaitAsync(RemainingOrDefault);
     }
@@ -172,7 +172,7 @@ public class CommitCollectorStageSpecs : Akka.TestKit.Xunit2.TestKit
 
         committedBatch.BatchSize.Should().Be(1);
         committedBatch.Offsets.Count.Should().Be(1); // 1 offset value per partition
-        committedBatch.Offsets.Last().Offset.Should().Be(msg1.Offset.Offset);
+        committedBatch.Offsets.Values.Last().Should().Be(msg1.Offset.Offset);
         offsetFactory.Committer.Commits.Count.Should().Be(1, "expected only one batch commit");
 
         await control.Shutdown().WaitAsync(RemainingOrDefault);
@@ -200,7 +200,7 @@ public class CommitCollectorStageSpecs : Akka.TestKit.Xunit2.TestKit
 
         committedBatch.BatchSize.Should().Be(2);
         committedBatch.Offsets.Count.Should().Be(1); // 1 offset value per partition
-        committedBatch.Offsets.Last().Offset.Should().Be(msg2.Offset.Offset);
+        committedBatch.Offsets.Values.Last().Should().Be(msg2.Offset.Offset);
         offsetFactory.Committer.Commits.Count.Should().Be(1, "expected only one batch commit");
 
         await control.Shutdown().WaitAsync(RemainingOrDefault);
@@ -257,10 +257,10 @@ public class CommitCollectorStageSpecs : Akka.TestKit.Xunit2.TestKit
         await sinkProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(10));
 
         // batches are committed using SelectAsyncUnordered, so order is not guaranteed
-        var lastBatch = batches.MaxBy(c => c.Offsets.Last().Offset.Value);
+        var lastBatch = batches.MaxBy(c => c.Offsets.Values.Last().Value);
 
         Assert.NotNull(lastBatch);
-        lastBatch.Offsets.Last().Offset.Should()
+        lastBatch.Offsets.Values.Last().Should()
             .Be(msg2.Offset.Offset, "expected only second message to be committed");
         offsetFactory.Committer.Commits.Count.Should().Be(2, "expected only two commits");
 
@@ -288,11 +288,11 @@ public class CommitCollectorStageSpecs : Akka.TestKit.Xunit2.TestKit
         await sinkProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(10));
 
         // batches are committed using SelectAsyncUnordered, so order is not guaranteed
-        var lastBatch = batches.MaxBy(c => c.Offsets.Last().Offset.Value);
+        var lastBatch = batches.MaxBy(c => c.Offsets.Values.Last().Value);
 
         Assert.NotNull(lastBatch);
-        lastBatch.Offsets.Last().Offset.Should()
-            .Be(batch2.Offsets.First().Offset, "expected only second message to be committed");
+        lastBatch.Offsets.Values.Last().Should()
+            .Be(batch2.Offsets.Values.First(), "expected only second message to be committed");
         offsetFactory.Committer.Commits.Count.Should().Be(2, "expected only two commits");
 
         await control.Shutdown().WaitAsync(RemainingOrDefault);
@@ -320,10 +320,10 @@ public class CommitCollectorStageSpecs : Akka.TestKit.Xunit2.TestKit
         await sinkProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(10));
 
         // batches are committed using SelectAsyncUnordered, so order is not guaranteed
-        var lastBatch = batches.MaxBy(c => c.Offsets.Last().Offset.Value);
+        var lastBatch = batches.MaxBy(c => c.Offsets.Values.Last().Value);
 
         Assert.NotNull(lastBatch);
-        lastBatch.Offsets.Last().Offset.Should()
+        lastBatch.Offsets.Values.Last().Should()
             .Be(msg2.Offset.Offset, "expected only second message to be committed");
         offsetFactory.Committer.Commits.Count.Should().Be(2, "expected only two commits");
 
@@ -354,13 +354,13 @@ public class CommitCollectorStageSpecs : Akka.TestKit.Xunit2.TestKit
 
         // batches are committed using SelectAsyncUnordered, so order is not guaranteed
         // Get the last 2 batches
-        var lastBatches = batches.OrderByDescending(c => c.Offsets.Last().Offset.Value)
+        var lastBatches = batches.OrderByDescending(c => c.Offsets.Values.Last().Value)
             .Take(2).ToList();
         var lastBatch = lastBatches[0];
         var secondLastBatch = lastBatches[1];
 
-        lastBatch.Offsets.Should().Contain(msg3.Offset, "expected the second offset of partition 1");
-        secondLastBatch.Offsets.Should().Contain(msg2.Offset, "expected the first offset of partition 2");
+        lastBatch.Offsets.Values.Should().Contain(msg3.Offset.Offset, "expected the second offset of partition 1");
+        secondLastBatch.Offsets.Values.Should().Contain(msg2.Offset.Offset, "expected the first offset of partition 2");
         offsetFactory.Committer.Commits.Count.Should().Be(3, "expected only three commits");
 
         await control.Shutdown().WaitAsync(RemainingOrDefault);

--- a/src/Akka.Streams.Kafka.Tests/Internal/ConsumerSpec.cs
+++ b/src/Akka.Streams.Kafka.Tests/Internal/ConsumerSpec.cs
@@ -75,13 +75,13 @@ akka.stream.materializer.debug.fuzzing-mode = on")
     {
     }
 
-    private readonly ImmutableList<CommittableMessage<K, V>> Messages =
+    private readonly ImmutableList<CommittableMessage<K, V>> _messages =
         Enumerable.Range(1, 1000).Select(CreateMessage).ToImmutableList();
 
     private async Task CheckMessagesReceivingAsync(List<List<CommittableMessage<K, V>>> msgss)
     {
         var mock = new MockConsumer<K, V>();
-        var (control, probe) = CreateCommitableSource(mock)
+        var (control, probe) = CreateCommittableSource(mock)
             .ToMaterialized(this.SinkProbe<CommittableMessage<K, V>>(), Keep.Both)
             .Run(Sys.Materializer());
 
@@ -94,7 +94,7 @@ akka.stream.materializer.debug.fuzzing-mode = on")
         var messages = msgss.SelectMany(m => m).Select(m => m);
         foreach (var message in messages)
         {
-            var received = probe.ExpectNext();
+            var received = await probe.ExpectNextAsync();
             received.Record.Message.Key.Should().Be(message.Record.Message.Key);
             received.Record.Message.Value.Should().Be(message.Record.Message.Value);
         }
@@ -102,10 +102,10 @@ akka.stream.materializer.debug.fuzzing-mode = on")
         await control.Shutdown().WithTimeoutAsync(RemainingOrDefault);
     }
 
-    private Source<CommittableMessage<K, V>, IControl> CreateCommitableSource(
+    private Source<CommittableMessage<K, V>, IControl> CreateCommittableSource(
         MockConsumer<K, V> mock, string groupId = "group1", string[]? topics = null)
     {
-        topics ??= new[] { "topic" };
+        topics ??= ["topic"];
         var settings = ConsumerSettings<K, V>.Create(Sys, Deserializers.Utf8, Deserializers.Utf8)
             .WithGroupId(groupId)
             .WithCloseTimeout(MockConsumer.CloseTimeout)
@@ -121,11 +121,11 @@ akka.stream.materializer.debug.fuzzing-mode = on")
 
     private Source<CommittableMessage<K, V>, IControl> CreateSourceWithMetadata(
         MockConsumer<K, V> mock,
-        Func<ConsumeResult<K, V>, string> metadataFromRecord,
+        Func<Record, string> metadataFromRecord,
         string groupId = "group1",
         string[]? topics = null)
     {
-        topics ??= new[] { "topic" };
+        topics ??= ["topic"];
         var settings = ConsumerSettings<K, V>.Create(Sys, Deserializers.Utf8, Deserializers.Utf8)
             .WithGroupId(groupId)
             .WithCloseTimeout(MockConsumer.CloseTimeout)
@@ -144,7 +144,7 @@ akka.stream.materializer.debug.fuzzing-mode = on")
     public void ShouldFailWhenPollFails()
     {
         var mock = new FailingMockConsumer<K, V>(new Exception("Fatal Kafka error"), 1);
-        var probe = CreateCommitableSource(mock)
+        var probe = CreateCommittableSource(mock)
             .ToMaterialized(this.SinkProbe<CommittableMessage<K, V>>(), Keep.Right)
             .Run(Sys.Materializer());
 
@@ -155,7 +155,7 @@ akka.stream.materializer.debug.fuzzing-mode = on")
     public async Task ShouldCompleteWhenStoppedAsync()
     {
         var mock = new MockConsumer<K, V>();
-        var (control, probe) = CreateCommitableSource(mock)
+        var (control, probe) = CreateCommittableSource(mock)
             .ToMaterialized(this.SinkProbe<CommittableMessage<K, V>>(), Keep.Both)
             .Run(Sys.Materializer());
 
@@ -170,7 +170,7 @@ akka.stream.materializer.debug.fuzzing-mode = on")
     public async Task ShouldCompleteWhenCanceledAsync()
     {
         var mock = new MockConsumer<K, V>();
-        var (control, probe) = CreateCommitableSource(mock)
+        var (control, probe) = CreateCommittableSource(mock)
             .ToMaterialized(this.SinkProbe<CommittableMessage<K, V>>(), Keep.Both)
             .Run(Sys.Materializer());
 
@@ -184,18 +184,18 @@ akka.stream.materializer.debug.fuzzing-mode = on")
     [Fact(DisplayName = "CommittableSource should emit messages received as one big chunk")]
     public async Task ShouldEmitBigChunkAsync() =>
         await CheckMessagesReceivingAsync(
-            new List<List<CommittableMessage<string, string>>> { Messages.ToList() });
+            new List<List<CommittableMessage<string, string>>> { _messages.ToList() });
 
     [Fact(DisplayName = "CommittableSource should emit messages received as medium chunk")]
-    public async Task ShouldEmitMediumChunkAsync() => await CheckMessagesReceivingAsync(Messages.Grouped(97));
+    public async Task ShouldEmitMediumChunkAsync() => await CheckMessagesReceivingAsync(_messages.Grouped(97));
 
     [Fact(DisplayName = "CommittableSource should emit messages received as chunked singles")]
     public async Task ShouldEmitSinglesAsync()
     {
         var splits = new List<List<CommittableMessage<string, string>>>();
-        foreach (var message in Messages)
+        foreach (var message in _messages)
         {
-            splits.Add(new List<CommittableMessage<string, string>> { message });
+            splits.Add([message]);
         }
 
         await CheckMessagesReceivingAsync(splits);
@@ -203,7 +203,7 @@ akka.stream.materializer.debug.fuzzing-mode = on")
 
     [Fact(DisplayName = "CommittableSource should emit messages received empties")]
     public async Task ShouldEmitEmptiesAsync() =>
-        await CheckMessagesReceivingAsync(Messages.Grouped(97)
+        await CheckMessagesReceivingAsync(_messages.Grouped(97)
             .Select(x => new List<CommittableMessage<string, string>>()).ToList());
 
     [Fact(DisplayName =
@@ -223,7 +223,7 @@ internal static class Extensions
             if (completed == timeoutTask)
                 throw new OperationCanceledException("Operation timed out");
             else
-                cts.Cancel();
+                await cts.CancelAsync();
         }
     }
 
@@ -238,7 +238,7 @@ internal static class Extensions
             if (index != 0 && index % size == 0)
             {
                 groups.Add(list);
-                list = new List<T>();
+                list = [];
             }
 
             index++;
@@ -260,7 +260,7 @@ internal static class Extensions
     public static T AssertAllStagesStopped<T>(this Akka.TestKit.Xunit2.TestKit spec, Func<T> block,
         IMaterializer materializer)
     {
-        if (!(materializer is ActorMaterializerImpl impl))
+        if (materializer is not ActorMaterializerImpl impl)
             return block();
 
         var probe = spec.CreateTestProbe(impl.System);

--- a/src/Akka.Streams.Kafka.Tests/KafkaIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/KafkaIntegrationTests.cs
@@ -72,6 +72,14 @@ public abstract class KafkaIntegrationTests : Akka.TestKit.Xunit2.TestKit
         get { return CommitterSettings.Create(Sys); }
     }
 
+    protected (IControl control, TestSubscriber.Probe<string> probe) CreateProbe(ConsumerSettings<Null, string> consumerSettings, params string[] topics)
+    {
+        return KafkaConsumer.PlainSource(consumerSettings, Subscriptions.Topics(topics))
+            .Select(c => c.Message.Value)
+            .ToMaterialized(this.SinkProbe<string>(), Keep.Both)
+            .Run(Sys);
+    }
+
     protected ConsumerSettings<TKey, TValue> CreateConsumerSettings<TKey, TValue>(string group) =>
         ConsumerSettings<TKey, TValue>.Create(Sys, null, null)
             .WithBootstrapServers(Fixture.KafkaServer)

--- a/src/Akka.Streams.Kafka/Messages/Committable.cs
+++ b/src/Akka.Streams.Kafka/Messages/Committable.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
+using Confluent.Kafka;
 
 namespace Akka.Streams.Kafka.Messages;
 
@@ -44,7 +45,7 @@ public interface ICommittableOffsetBatch : ICommittable
     /// <summary>
     /// Get current offset positions
     /// </summary>
-    IImmutableSet<GroupTopicPartitionOffset> Offsets { get; }
+    IImmutableDictionary<GroupTopicPartition, Offset> Offsets { get; }
 
     /// <summary>
     /// Returns <c>true</c> if the batch contains no commits.

--- a/src/Akka.Streams.Kafka/Messages/CommittableOffsetBatch.cs
+++ b/src/Akka.Streams.Kafka/Messages/CommittableOffsetBatch.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Akka.Streams.Kafka.Extensions;
 using Akka.Streams.Kafka.Helpers;
 using Akka.Streams.Kafka.Stages.Consumers;
+using Confluent.Kafka;
 
 namespace Akka.Streams.Kafka.Messages;
 
@@ -34,17 +35,15 @@ internal sealed class CommittableOffsetBatch : ICommittableOffsetBatch
     
     public long BatchSize { get; }
 
+    /// INTERNAL COMMENT
     /// Represents the offsets as they are, rather than how they're going to be committed.
     ///
     /// We have to +1 all offsets upon commit - which is what you get inside OffsetsAndMetadata.
-    ///
-    /// This is useful for debugging and for testing, but not much else.
-    public IImmutableSet<GroupTopicPartitionOffset> Offsets
+    public IImmutableDictionary<GroupTopicPartition, Offset> Offsets
     {
         get
         {
-            return OffsetsAndMetadata.Select(o => new GroupTopicPartitionOffset(o.Key, o.Value.Offset - 1L))
-                .ToImmutableHashSet();
+            return OffsetsAndMetadata.ToImmutableDictionary(c => c.Key, c => new Offset(c.Value.Offset.Value - 1L));
         }
     }
 
@@ -168,7 +167,7 @@ internal sealed class CommittableOffsetBatch : ICommittableOffsetBatch
         var newOffsets = OffsetsAndMetadata.Where(o => p(o.Key))
             .ToImmutableDictionary(o => o.Key, o => o.Value);
         var newCommiters =
-            Offsets.ToImmutableDictionary(c => c.GroupTopicPartition, v => CommitterFor(v.GroupTopicPartition));
+            Offsets.ToImmutableDictionary(c => c.Key, c => CommitterFor(c.Key));
         return new CommittableOffsetBatch(newOffsets, newCommiters, BatchSize);
     }
 

--- a/src/Akka.Streams.Kafka/Messages/CommittableOffsetBatch.cs
+++ b/src/Akka.Streams.Kafka/Messages/CommittableOffsetBatch.cs
@@ -130,7 +130,12 @@ internal sealed class CommittableOffsetBatch : ICommittableOffsetBatch
         var key = partitionOffset.GroupTopicPartition;
         var metadata = newOffset is ICommittableOffsetMetadata withMetadata ? withMetadata.Metadata : string.Empty;
 
-        var newOffsets = OffsetsAndMetadata.SetItem(key, new OffsetAndMetadata(partitionOffset.Offset, metadata));
+        /*
+         * https://kafka.apache.org/10/javadoc/org/apache/kafka/clients/consumer/KafkaConsumer.html
+         * "The committed offset should always be the offset of the next message that your application will read.
+         * Thus, when calling commitSync(offsets) you should add one to the offset of the last message processed."
+         */
+        var newOffsets = OffsetsAndMetadata.SetItem(key, new OffsetAndMetadata(partitionOffset.Offset + 1, metadata));
 
         var newCommitter = newOffset switch
         {

--- a/src/Akka.Streams.Kafka/Messages/CommittableOffsetBatch.cs
+++ b/src/Akka.Streams.Kafka/Messages/CommittableOffsetBatch.cs
@@ -31,16 +31,19 @@ internal sealed class CommittableOffsetBatch : ICommittableOffsetBatch
         Committers = committers;
         BatchSize = batchSize;
     }
-
-    /// <inheritdoc />
+    
     public long BatchSize { get; }
 
-    /// <inheritdoc />
+    /// Represents the offsets as they are, rather than how they're going to be committed.
+    ///
+    /// We have to +1 all offsets upon commit - which is what you get inside OffsetsAndMetadata.
+    ///
+    /// This is useful for debugging and for testing, but not much else.
     public IImmutableSet<GroupTopicPartitionOffset> Offsets
     {
         get
         {
-            return OffsetsAndMetadata.Select(o => new GroupTopicPartitionOffset(o.Key, o.Value.Offset))
+            return OffsetsAndMetadata.Select(o => new GroupTopicPartitionOffset(o.Key, o.Value.Offset - 1L))
                 .ToImmutableHashSet();
         }
     }

--- a/src/Akka.Streams.Kafka/Stages/Consumers/CommitObservationLogic.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/CommitObservationLogic.cs
@@ -96,8 +96,8 @@ internal sealed class CommitObservationLogic
                     OffsetBatch = OffsetBatch.Updated(dOffset);
                     break;
                 case CommittableOffsetBatch dOffsetBatch
-                    when dOffsetBatch.OffsetsAndMetadata.ContainsKey(groupTopicPartition)
-                         && dOffsetBatch.OffsetsAndMetadata[groupTopicPartition].Offset < offset:
+                    when dOffsetBatch.Offsets.ContainsKey(groupTopicPartition)
+                         && dOffsetBatch.Offsets[groupTopicPartition].Value < offset:
                     DeferredOffsets = DeferredOffsets.SetItem(groupTopicPartition, committable);
                     OffsetBatch = OffsetBatch.Updated(dOffsetBatch);
                     break;


### PR DESCRIPTION
## Changes

Tracking down some additional N+1 errors with offset committing

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).