### PR TITLE
added v1.5.40.1 release notes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,9 +7,8 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>1.5.40</VersionPrefix>
-    <PackageReleaseNotes>* [Major bug fix: Committers: fixed n+1 errors with offset committing](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/484)
-* [Upgraded to Akka.NET v1.5.40](https://github.com/akkadotnet/akka.net/releases/tag/1.5.40)</PackageReleaseNotes>
+    <VersionPrefix>1.5.40.1</VersionPrefix>
+    <PackageReleaseNotes>* Fixed another major N+1 bug when committing offsets to Kafka: [Committing: fix N+1 issues in `CommittableOffsetBatch`](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/487)</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Visual Studio C# settings -->

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+#### 1.5.40.1 March 24th 2025 ####
+
+* Fixed another major N+1 bug when committing offsets to Kafka: [Committing: fix N+1 issues in `CommittableOffsetBatch`](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/487)
+
+
 #### 1.5.40 March 24th 2025 ####
 
 * [Major bug fix: Committers: fixed n+1 errors with offset committing](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/484)


### PR DESCRIPTION
#### 1.5.40.1 March 24th 2025 ####

* Fixed another major N+1 bug when committing offsets to Kafka: [Committing: fix N+1 issues in `CommittableOffsetBatch`](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/487)