### PR TITLE
413 - only process consume errors if decider does not return Directive.Resume

### DIFF
--- a/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Actors/KafkaConsumerActor.cs
@@ -976,10 +976,11 @@ internal class KafkaConsumerActor<K, V> : ActorBase, ILogReceive, IWithTimers
             return;
 
         var directive = _decider(exception);
-        ProcessError(exception);
         if (directive == Directive.Resume)
             return;
 
+        ProcessError(exception);
+        
         Timers.CancelAll();
         if (directive == Directive.Stop && _log.IsErrorEnabled)
             _log.Error(exception, "Exception when polling from consumer, stopping actor: {0}", exception.Message);


### PR DESCRIPTION
Fixes #413

## Changes

Return from `ProcessExceptions()` in `KafkaConsumerActor` when decider results in `Directive.Resume` 

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [ ] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [ ] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [ ] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed, if any.
* [ ] I have added website documentation for this feature.

### Latest `dev` Benchmarks 

Include data from the [relevant benchmark](https://getakka.net/community/contributing/index.html#improve-performance) prior to this change here.

### This PR's Benchmarks

Include data from after this change here.
