### PR TITLE
upgrade to Akka.NET v1.5.46 + fix PlainPartitionedManualOffsetSource seek timeout race condition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,4 @@ build/
 .idea
 /.cursor
 BenchmarkDotNet.Artifacts/
+/.claude

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,10 +2,9 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <!-- Nuget package versions -->
-    <AkkaVersion>1.5.42</AkkaVersion>
+    <AkkaVersion>1.5.46</AkkaVersion>
     <!-- Unit test Nuget package versions -->
     <NBenchVersion>1.2.2</NBenchVersion>
-    <TestSdkVersion>17.4.1</TestSdkVersion>
     <AspireVersion>9.3.0</AspireVersion>
   </PropertyGroup>
   <!-- App dependencies -->

--- a/examples/EventHub.Consumer/Program.cs
+++ b/examples/EventHub.Consumer/Program.cs
@@ -55,10 +55,10 @@ internal class Program
 
         var committerDefaults = CommitterSettings.Create(system);
 
-        // Comment for simple no-commit consumer
+        // Comment for committable consumer
         var control = KafkaConsumer.CommittableSource(consumerSettings, subscription)
             .SelectAsync(1, msg =>
-                Business(msg.Record).ContinueWith(done => (ICommittable)msg.CommitableOffset))
+                Business(msg.Record).ContinueWith(ICommittable (_) => msg.CommitableOffset))
             .ToMaterialized(
                 Committer.Sink(committerDefaults.WithMaxBatch(1)),
                 DrainingControl<NotUsed>.Create)

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/SubSourceLogic.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/SubSourceLogic.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Streams.Dsl;
@@ -139,6 +140,11 @@ internal class SubSourceLogic<K, V, TMessage> : TimerGraphStageLogic
     /// Kafka has signalled these partitions are revoked, but some may be re-assigned just after revoking.
     /// </summary>
     private IImmutableSet<TopicPartition> _partitionsToRevoke = ImmutableHashSet<TopicPartition>.Empty;
+
+    /// <summary>
+    /// Cancellation token source for shutting down seek operations when stage is stopping
+    /// </summary>
+    private readonly CancellationTokenSource _shutdownTokenSource = new();
 
     protected StageActor SourceActor { get; private set; } = null!;
     public IActorRef ConsumerActor { get; private set; } = null!;
@@ -295,9 +301,15 @@ internal class SubSourceLogic<K, V, TMessage> : TimerGraphStageLogic
 
     public override void PostStop()
     {
+        // Cancel any ongoing seek operations
+        _shutdownTokenSource.Cancel();
+        
         ConsumerActor.Tell(new KafkaConsumerActorMetadata.Internal.StopFromStage(_shape.ToString()), SourceActor.Ref);
 
         Control.OnShutdown();
+        
+        // Clean up cancellation token
+        _shutdownTokenSource.Dispose();
 
         base.PostStop();
     }
@@ -382,14 +394,32 @@ internal class SubSourceLogic<K, V, TMessage> : TimerGraphStageLogic
             try
             {
                 await ConsumerActor.Ask(new KafkaConsumerActorMetadata.Internal.Seek(offsets),
-                    TimeSpan.FromSeconds(10));
+                    TimeSpan.FromSeconds(10), _shutdownTokenSource.Token);
                 _updatePendingPartitionsAndEmitSubSourcesCallback(formerlyUnknown);
             }
-            catch (Exception)
+            catch (OperationCanceledException) when (_shutdownTokenSource.IsCancellationRequested)
             {
-                // only exceptions that can be thrown here are related to TCS cancellation / timeout
-                _stageFailCallback(new ConsumerFailed(
-                    $"{_actorNumber} Consumer failed during seek, Ask timed out. Partitions: {offsets.JoinToString(", ")}"));
+                // Stage is shutting down, this is expected - don't treat as fatal error
+                if (Log.IsDebugEnabled)
+                    Log.Debug("#{0} Seek operation cancelled due to stage shutdown. Partitions: {1}", 
+                        _actorNumber, offsets.JoinToString(", "));
+            }
+            catch (Exception ex)
+            {
+                // Other exceptions (timeout, etc.) - check if we're shutting down before failing
+                if (_shutdownTokenSource.IsCancellationRequested)
+                {
+                    // Stage is shutting down, timeout is expected
+                    if (Log.IsDebugEnabled)
+                        Log.Debug("#{0} Seek operation timed out during stage shutdown (expected). Partitions: {1}", 
+                            _actorNumber, offsets.JoinToString(", "));
+                }
+                else
+                {
+                    // Unexpected timeout while stage is still active
+                    _stageFailCallback(new ConsumerFailed(
+                        $"{_actorNumber} Consumer failed during seek, Ask timed out. Partitions: {offsets.JoinToString(", ")}", ex));
+                }
             }
         }
     }
@@ -499,6 +529,9 @@ internal class SubSourceLogic<K, V, TMessage> : TimerGraphStageLogic
     {
         Log.Info("Completing. Partitions [{0}], StageActor {1}", string.Join(", ", _subSources.Keys), SourceActor.Ref);
         SetKeepGoing(true);
+
+        // Cancel any ongoing seek operations immediately to avoid timeouts
+        _shutdownTokenSource.Cancel();
 
         // TODO from alpakka: we should wait for subsources to be shutdown and next shutdown main stage
         _subSources.Values.Select(c => c.ControlAndStageActor.Control).ForEach(control => control.Shutdown());

--- a/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/SubSourceLogic.cs
+++ b/src/Akka.Streams.Kafka/Stages/Consumers/Abstract/SubSourceLogic.cs
@@ -145,6 +145,16 @@ internal class SubSourceLogic<K, V, TMessage> : TimerGraphStageLogic
     /// Cancellation token source for shutting down seek operations when stage is stopping
     /// </summary>
     private readonly CancellationTokenSource _shutdownTokenSource = new();
+    
+    /// <summary>
+    /// Track when the stage started to detect race conditions
+    /// </summary>
+    private readonly DateTime _startTime = DateTime.UtcNow;
+    
+    /// <summary>
+    /// Track if seek operation is in progress to detect race conditions
+    /// </summary>
+    private volatile bool _seekInProgress = false;
 
     protected StageActor SourceActor { get; private set; } = null!;
     public IActorRef ConsumerActor { get; private set; } = null!;
@@ -391,21 +401,32 @@ internal class SubSourceLogic<K, V, TMessage> : TimerGraphStageLogic
 
         async Task AskToSeekOffsets()
         {
+            _seekInProgress = true;
+            
+            if (Log.IsDebugEnabled)
+                Log.Debug("#{0} Starting seek operation for partitions: {1}", _actorNumber, offsets.JoinToString(", "));
+                
             try
             {
                 await ConsumerActor.Ask(new KafkaConsumerActorMetadata.Internal.Seek(offsets),
                     TimeSpan.FromSeconds(10), _shutdownTokenSource.Token);
+                    
+                if (Log.IsDebugEnabled)
+                    Log.Debug("#{0} Seek operation completed successfully", _actorNumber);
+                    
                 _updatePendingPartitionsAndEmitSubSourcesCallback(formerlyUnknown);
             }
             catch (OperationCanceledException) when (_shutdownTokenSource.IsCancellationRequested)
             {
                 // Stage is shutting down, this is expected - don't treat as fatal error
                 if (Log.IsDebugEnabled)
-                    Log.Debug("#{0} Seek operation cancelled due to stage shutdown. Partitions: {1}", 
+                    Log.Debug("#{0} Seek operation cancelled due to stage shutdown (expected). Partitions: {1}", 
                         _actorNumber, offsets.JoinToString(", "));
             }
             catch (Exception ex)
             {
+                var timeSinceStart = DateTime.UtcNow.Subtract(_startTime);
+                
                 // Other exceptions (timeout, etc.) - check if we're shutting down before failing
                 if (_shutdownTokenSource.IsCancellationRequested)
                 {
@@ -416,10 +437,22 @@ internal class SubSourceLogic<K, V, TMessage> : TimerGraphStageLogic
                 }
                 else
                 {
+                    // Check for race condition pattern - very fast failure
+                    if (timeSinceStart.TotalMilliseconds < 100)
+                    {
+                        Log.Warning("#{0} Seek operation failed very quickly ({1}ms after start) - possible race condition. " +
+                                   "Error: {2}, Partitions: {3}", 
+                            _actorNumber, timeSinceStart.TotalMilliseconds, ex.Message, offsets.JoinToString(", "));
+                    }
+                    
                     // Unexpected timeout while stage is still active
                     _stageFailCallback(new ConsumerFailed(
                         $"{_actorNumber} Consumer failed during seek, Ask timed out. Partitions: {offsets.JoinToString(", ")}", ex));
                 }
+            }
+            finally
+            {
+                _seekInProgress = false;
             }
         }
     }
@@ -527,6 +560,22 @@ internal class SubSourceLogic<K, V, TMessage> : TimerGraphStageLogic
 
     private void PerformShutdown()
     {
+        var timeSinceStart = DateTime.UtcNow.Subtract(_startTime);
+        
+        // Only log if this looks like the race condition (very fast shutdown with seek in progress)
+        if (timeSinceStart.TotalMilliseconds < 100 && _seekInProgress)
+        {
+            Log.Warning("#{0} Potential race condition detected: PerformShutdown called {1}ms after start " +
+                       "with seek operation still in progress. Pending: {2}, InStartup: {3}, SubSources: {4}",
+                _actorNumber, timeSinceStart.TotalMilliseconds, _pendingPartitions.Count, 
+                _partitionsInStartup.Count, _subSources.Count);
+        }
+        else if (Log.IsDebugEnabled)
+        {
+            Log.Debug("#{0} PerformShutdown called normally after {1}ms. SeekInProgress: {2}", 
+                _actorNumber, timeSinceStart.TotalMilliseconds, _seekInProgress);
+        }
+        
         Log.Info("Completing. Partitions [{0}], StageActor {1}", string.Join(", ", _subSources.Keys), SourceActor.Ref);
         SetKeepGoing(true);
 


### PR DESCRIPTION
This PR includes:

1. **Akka.NET upgrade**: Updated to v1.5.46
2. **Race condition fix**: Resolved seek timeout hang in PlainPartitionedManualOffsetSource during stream cancellation

## Race Condition Fix

Addresses issue (close #496) - PlainPartitionedManualOffsetSource would hang for 10 seconds when cancelled during seek operations.

**Root cause**: Seek operation didn't respect stream cancellation, causing unnecessary timeouts.

**Solution**: Added proper cancellation token support to gracefully handle stream shutdown during seek operations.

**Impact**: 
- Eliminates 10-second hangs during stream cancellation
- Improves resource cleanup timing  
- Better error semantics (cancellation vs timeout)
- Resolves flaky integration test