### PR TITLE
Readme update - ToImmutableSet method no longer accessible

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ var multiMessage = ProducerMessage.Multi(new[]
 {
     new ProducerRecord<string, string>(topic2, record.Key, record.Value),
     new ProducerRecord<string, string>(topic3, record.Key, record.Value)
-}.ToImmutableSet(), passThrough);
+}.ToImmutableHashSet(), passThrough);
 ```
 
 The flow with `ProducerMessage.MultiMessage` will continue as `ProducerMessage.MultiResult` elements containing:


### PR DESCRIPTION
## Changes

Minor document update to change the method used as the extension method is now in an internal class. The class was moved to internal as part of this PR https://github.com/akkadotnet/Akka.Streams.Kafka/pull/464/files#diff-0d6c96766b652828ae0c3a20e524d5bc529c312a2c844f7ed92020bcb057a3ec

Updated document to use the same method the extension method was calling https://github.com/akkadotnet/Akka.Streams.Kafka/blob/dev/src/Akka.Streams.Kafka/Extensions/CollectionExtensions.cs#L36