### PR TITLE
Update to Akka.NET v1.5.55

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,8 +7,8 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>1.5.40.1</VersionPrefix>
-    <PackageReleaseNotes>* Fixed another major N+1 bug when committing offsets to Kafka: [Committing: fix N+1 issues in `CommittableOffsetBatch`](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/487)</PackageReleaseNotes>
+    <VersionPrefix>1.5.55</VersionPrefix>
+    <PackageReleaseNotes>* [Upgraded to Akka.NET v1.5.55](https://github.com/akkadotnet/akka.net/releases/tag/1.5.55) - see [PR #505](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/505)</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Visual Studio C# settings -->

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+#### 1.5.55 October 26th 2025 ####
+
+* [Upgraded to Akka.NET v1.5.55](https://github.com/akkadotnet/akka.net/releases/tag/1.5.55) - see [PR #505](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/505)
+
 #### 1.5.46 August 12th 2025 ####
 
 * [Upgraded to Akka.NET v1.5.46](https://github.com/akkadotnet/akka.net/releases/tag/1.5.46)


### PR DESCRIPTION
## Summary

This release updates Akka.Streams.Kafka to use Akka.NET v1.5.55.

## Changes

* Updated Akka.NET dependency to v1.5.55 (#505)
* Updated RELEASE_NOTES.md with version 1.5.55
* Updated version metadata in Directory.Build.props

## Test Plan

- [x] Build script executed successfully
- [x] Version metadata updated correctly
- [ ] All CI checks pass