### PR TITLE
Bump Akka.NET to 1.5.59

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,8 +7,8 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>1.5.55</VersionPrefix>
-    <PackageReleaseNotes>* [Upgraded to Akka.NET v1.5.55](https://github.com/akkadotnet/akka.net/releases/tag/1.5.55) - see [PR #505](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/505)</PackageReleaseNotes>
+    <VersionPrefix>1.5.59</VersionPrefix>
+    <PackageReleaseNotes>* [Upgraded to Akka.NET v1.5.59](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Visual Studio C# settings -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <!-- Nuget package versions -->
-    <AkkaVersion>1.5.55</AkkaVersion>
+    <AkkaVersion>1.5.59</AkkaVersion>
     <!-- Unit test Nuget package versions -->
     <NBenchVersion>1.2.2</NBenchVersion>
     <AspireVersion>9.3.0</AspireVersion>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+#### 1.5.59 January 26th 2026 ####
+
+* [Upgraded to Akka.NET v1.5.59](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)
+
 #### 1.5.55 October 26th 2025 ####
 
 * [Upgraded to Akka.NET v1.5.55](https://github.com/akkadotnet/akka.net/releases/tag/1.5.55) - see [PR #505](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/505)


### PR DESCRIPTION
## Summary
- Upgrade Akka.NET to 1.5.59

## Changes
- [Akka.NET 1.5.59 Release Notes](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)