### PR TITLE
Fix: Use windows-2022 in release pipeline

### DIFF
--- a/build-system/windows-release.yaml
+++ b/build-system/windows-release.yaml
@@ -19,7 +19,7 @@ variables:
 jobs:
   - job: Release
     pool:
-      vmImage: windows-latest
+      vmImage: windows-2022
       demands: Cmd
     steps:
       - powershell: ./build.ps1


### PR DESCRIPTION
Azure DevOps windows-latest bug workaround.