### PR TITLE
Extract only latest release block for GitHub release body

### DIFF
--- a/build-system/windows-release.yaml
+++ b/build-system/windows-release.yaml
@@ -32,11 +32,20 @@ jobs:
       - script: dotnet nuget push "$(Build.ArtifactStagingDirectory)\nuget\*.nupkg" --api-key $(nugetKey) --source https://api.nuget.org/v3/index.json --skip-duplicate
         displayName: 'Publish to NuGet.org'
 
+      - powershell: |
+          $content = Get-Content RELEASE_NOTES.md -Raw
+          if ($content -match '(?s)(####.+?)(?=\n####|\z)') {
+            $Matches[1].Trim() | Set-Content RELEASE_NOTES_LATEST.md
+          } else {
+            $content | Set-Content RELEASE_NOTES_LATEST.md
+          }
+        displayName: 'Extract latest release notes'
+
       - task: GitHubRelease@0
         displayName: 'GitHub release (create)'
         inputs:
           gitHubConnection: $(githubConnectionName)
           repositoryName: $(githubRepositoryName)
           title: '$(projectName) v$(Build.SourceBranchName)'
-          releaseNotesFile: 'RELEASE_NOTES.md'
+          releaseNotesFile: 'RELEASE_NOTES_LATEST.md'
           assets: '$(Build.ArtifactStagingDirectory)/nuget/*.nupkg'


### PR DESCRIPTION
## Summary
- GitHub releases were using the entire RELEASE_NOTES.md, causing every release to contain the full changelog
- Added PowerShell step to extract only the first #### block into RELEASE_NOTES_LATEST.md
- Release task now uses RELEASE_NOTES_LATEST.md instead of the full file