### PR TITLE
Update RELEASE_NOTES.md for 1.5.67 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 #### 1.5.67 April 28th 2026 ####
 
-* [Upgraded to Akka.NET v1.5.67](https://github.com/akkadotnet/akka.net/releases/tag/1.5.67) - see [PR #521](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/521)
+* [Upgraded to Akka.NET v1.5.67](https://github.com/akkadotnet/akka.net/releases/tag/1.5.67)
 
 #### 1.5.59 January 26th 2026 ####
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+#### 1.5.67 April 28th 2026 ####
+
+* [Upgraded to Akka.NET v1.5.67](https://github.com/akkadotnet/akka.net/releases/tag/1.5.67) - see [PR #521](https://github.com/akkadotnet/Akka.Streams.Kafka/pull/521)
+
 #### 1.5.59 January 26th 2026 ####
 
 * [Upgraded to Akka.NET v1.5.59](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)


### PR DESCRIPTION
## 1.5.67 April 28th 2026 

* [Upgraded to Akka.NET v1.5.67](https://github.com/akkadotnet/akka.net/releases/tag/1.5.67)
