### PR TITLE
feat: bump to Akka.NET v1.5.68

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>1.5.59</VersionPrefix>
+    <VersionPrefix>1.5.68</VersionPrefix>
     <PackageReleaseNotes>* [Upgraded to Akka.NET v1.5.59](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
@@ -34,8 +34,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageProjectUrl>https://github.com/akkadotnet/Akka.Streams.Kafka</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <PackageReleaseNotes>* [Upgraded to Akka.NET v1.5.39](https://github.com/akkadotnet/akka.net/releases/tag/1.5.39)
-      * [Resolved: Kafka Producer - Exception occured inside SelectAsync - Cancellation cause must not be null](https://github.com/akkadotnet/Akka.Streams.Kafka/issues/426)
+    <PackageReleaseNotes>* [Upgraded to Akka.NET v1.5.68](https://github.com/akkadotnet/akka.net/releases/tag/1.5.68)
     </PackageReleaseNotes>
   </PropertyGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <!-- Nuget package versions -->
-    <AkkaVersion>1.5.67</AkkaVersion>
+    <AkkaVersion>1.5.68</AkkaVersion>
     <!-- Unit test Nuget package versions -->
     <NBenchVersion>1.2.2</NBenchVersion>
     <AspireVersion>9.3.0</AspireVersion>


### PR DESCRIPTION
## Changes
- Bumped Akka.NET dependency from 1.5.67 to 1.5.68
- Updated VersionPrefix from 1.5.59 to 1.5.68
- Updated release notes

## Motivation
This brings Akka.Streams.Kafka in line with the latest Akka.NET stable release and includes the OTEL trace context propagation fixes from #8160 which may resolve graph interpreter compatibility issues.

## CI
Please monitor CI for any build issues.
