### PR TITLE
Fix xUnit2013 analyzer warnings and complete FluentAssertions migration

### DIFF
--- a/src/Akka.Streams.Kafka.Tests/BugFix240SupervisionStrategy.cs
+++ b/src/Akka.Streams.Kafka.Tests/BugFix240SupervisionStrategy.cs
@@ -20,7 +20,6 @@ using Akka.Streams.Kafka.Settings;
 using Akka.Streams.Kafka.Supervision;
 using Akka.Streams.Supervision;
 using Confluent.Kafka;
-using FluentAssertions;
 using Xunit;
 using Akka.Streams.TestKit;
 
@@ -76,7 +75,7 @@ public class BugFix240SupervisionStrategy : KafkaIntegrationTests
 
         probe.Cancel();
 
-        callCount.Should().BeGreaterThan(0);
+        Assert.True((callCount) > (0));
     }
 
     [Fact]
@@ -125,7 +124,7 @@ public class BugFix240SupervisionStrategy : KafkaIntegrationTests
 
         probe.Cancel();
 
-        callCount.Should().Be(1);
+        Assert.Equal(1, callCount);
     }
 
     // In this test, the exception happened inside the consumer source while it is deserializing the value
@@ -186,12 +185,11 @@ public class BugFix240SupervisionStrategy : KafkaIntegrationTests
         probe.ExpectNoMsg(TimeSpan.FromSeconds(2));
         probe.Cancel();
 
-        pulled.Should().BeEquivalentTo(new[] { 1, 2, 3, 4, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 },
-            opt => opt.WithStrictOrdering());
+        Assert.Equivalent(new[] { 1, 2, 3, 4, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }, pulled);
 
         // Decider should be called twice, because deciders are called in BaseSingleSourceLogic and KafkaConsumerActor 
-        callCount.Should().Be(2);
-        serializationCallCount.Should().Be(2);
+        Assert.Equal(2, callCount);
+        Assert.Equal(2, serializationCallCount);
     }
 
     [Fact]
@@ -234,9 +232,9 @@ public class BugFix240SupervisionStrategy : KafkaIntegrationTests
 
         // stream fails at index 7
         var err = await probe.ExpectEventAsync();
-        err.Should().BeOfType<TestSubscriber.OnError>();
+        Assert.True((err) is TestSubscriber.OnError);
         var exception = ((TestSubscriber.OnError)err).Cause;
-        exception.Message.Should().Contain("BOOM!");
+        Assert.Contains("BOOM!", exception.Message);
 
         // stream should be dead here
         await probe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(200));
@@ -259,7 +257,7 @@ public class BugFix240SupervisionStrategy : KafkaIntegrationTests
         // BUG: we 6 appears twice in this list not due to any Kafka stuff, but because the final stream element is the 6th element
         // and still gets emitted into the original stream even though its offset is never committed.
         // so we call .ToHashSet here to eliminate the duplicate.
-        offsets.ToHashSet().Should().BeEquivalentTo(Enumerable.Range(1, 11).Select(c => c.ToString()));
+        Assert.Equivalent(Enumerable.Range(1, 11).Select(c => c.ToString()), offsets.ToHashSet());
         return;
 
         Sink<CommittableMessage<Null, string>, NotUsed> CreateSink()
@@ -328,7 +326,7 @@ public class BugFix240SupervisionStrategy : KafkaIntegrationTests
         await GuardWithTimeoutAsync(drainingControl.DrainAndShutdown(), TimeSpan.FromSeconds(10));
 
         // There should be only 1 decider call
-        callCount.Should().Be(1);
+        Assert.Equal(1, callCount);
 
         // Assert that all of the messages, except for those that failed in the stage, got committed
         var settings = CreateConsumerSettings<Null, string>(group);
@@ -347,7 +345,7 @@ public class BugFix240SupervisionStrategy : KafkaIntegrationTests
 
         // Message "5" is missing because the exception happened downstream of the source and we chose to
         // ignore it in the decider
-        messages.Should().BeEquivalentTo(new[] { "1", "2", "3", "4", "6", "7", "8", "9", "10" });
+        Assert.Equivalent(new[] { "1", "2", "3", "4", "6", "7", "8", "9", "10" }, messages);
         probe.Cancel();
         return;
 
@@ -397,7 +395,7 @@ public class BugFix240SupervisionStrategy : KafkaIntegrationTests
             Log.Info($"> [{i}]: {message}");
         }
 
-        callCount.Should().Be(1);
+        Assert.Equal(1, callCount);
         probe.Cancel();
         return;
 
@@ -452,7 +450,7 @@ public class BugFix240SupervisionStrategy : KafkaIntegrationTests
             Log.Info($"> [{i}]: {message}");
         }
 
-        decider.CallCount.Should().Be(1);
+        Assert.Equal(1, decider.CallCount);
         probe.Cancel();
     }
 
@@ -483,7 +481,7 @@ public class BugFix240SupervisionStrategy : KafkaIntegrationTests
         probe.Request(elementsCount);
         probe.ExpectNoMsg(TimeSpan.FromSeconds(10));
         // this is twice elementCount because Decider is called twice on each exceptions
-        callCount.Should().Be(elementsCount * 2);
+        Assert.Equal(elementsCount * 2, callCount);
         probe.Cancel();
         return;
 
@@ -525,7 +523,7 @@ public class BugFix240SupervisionStrategy : KafkaIntegrationTests
         probe.Request(elementsCount);
         probe.ExpectNoMsg(TimeSpan.FromSeconds(10));
         // this is twice elementCount because Decider is called twice on each exceptions
-        decider.CallCount.Should().Be(elementsCount * 2);
+        Assert.Equal(elementsCount * 2, decider.CallCount);
         probe.Cancel();
     }
 
@@ -573,10 +571,10 @@ public class BugFix240SupervisionStrategy : KafkaIntegrationTests
             .RunWith(this.SinkProbe<int>(), Materializer);
 
         var error = probe.Request(elementsCount).ExpectEvent(TimeSpan.FromSeconds(5));
-        error.Should().BeOfType<TestSubscriber.OnError>();
+        Assert.True((error) is TestSubscriber.OnError);
         var exception = ((TestSubscriber.OnError)error).Cause;
-        exception.Should().BeOfType<ConsumeException>();
-        ((ConsumeException)exception).Error.IsSerializationError().Should().BeTrue();
+        Assert.True((exception) is ConsumeException);
+        Assert.True(((ConsumeException)exception).Error.IsSerializationError());
 
         probe.ExpectNoMsg(TimeSpan.FromSeconds(5));
         probe.Cancel();

--- a/src/Akka.Streams.Kafka.Tests/ConfigSettingsSpec.cs
+++ b/src/Akka.Streams.Kafka.Tests/ConfigSettingsSpec.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 //  <copyright file="ConfigSettingsSpec.cs" company="Akka.NET Project">
 //      Copyright (C) 2023 - 2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
 // </copyright>
@@ -8,7 +8,6 @@ using System;
 using Akka.Configuration;
 using Akka.Streams.Kafka.Settings;
 using Confluent.Kafka;
-using FluentAssertions;
 using Xunit;
 
 namespace Akka.Streams.Kafka.Tests;
@@ -28,11 +27,11 @@ akka.kafka.consumer.kafka-clients {{
             ").WithFallback(KafkaExtensions.DefaultSettings).GetConfig("akka.kafka.consumer");
 
         var settings = ConsumerSettings<string, string>.Create(conf, null, null);
-        settings.GetProperty("bootstrap.servers").Should().Be("localhost:9092");
-        settings.GetProperty("client.id").Should().Be("client1");
-        settings.GetProperty("foo").Should().Be("bar");
-        settings.GetProperty("bootstrap.foo").Should().Be("baz");
-        settings.GetProperty("enable.auto.commit").Should().Be("false");
+        Assert.Equal("localhost:9092", settings.GetProperty("bootstrap.servers"));
+        Assert.Equal("client1", settings.GetProperty("client.id"));
+        Assert.Equal("bar", settings.GetProperty("foo"));
+        Assert.Equal("baz", settings.GetProperty("bootstrap.foo"));
+        Assert.Equal("false", settings.GetProperty("enable.auto.commit"));
     }
 
     [Fact]
@@ -50,11 +49,11 @@ akka.kafka.consumer.kafka-clients {{
         };
 
         settings = settings.WithConsumerConfig(config);
-        settings.GetProperty("bootstrap.servers").Should().Be("localhost:9092");
-        settings.GetProperty("auto.offset.reset").Should().Be("latest");
-        settings.GetProperty("enable.auto.commit").Should().Be("True");
-        settings.GetProperty("group.id").Should().Be("group1");
-        settings.GetProperty("client.id").Should().Be("client1");
+        Assert.Equal("localhost:9092", settings.GetProperty("bootstrap.servers"));
+        Assert.Equal("latest", settings.GetProperty("auto.offset.reset"));
+        Assert.Equal("True", settings.GetProperty("enable.auto.commit"));
+        Assert.Equal("group1", settings.GetProperty("group.id"));
+        Assert.Equal("client1", settings.GetProperty("client.id"));
     }
 
     [Fact]
@@ -70,10 +69,10 @@ akka.kafka.producer.kafka-clients {{
             ").WithFallback(KafkaExtensions.DefaultSettings).GetConfig("akka.kafka.producer");
 
         var settings = ProducerSettings<string, string>.Create(conf, null, null);
-        settings.GetProperty("bootstrap.servers").Should().Be("localhost:9092");
-        settings.GetProperty("client.id").Should().Be("client1");
-        settings.GetProperty("foo").Should().Be("bar");
-        settings.GetProperty("bootstrap.foo").Should().Be("baz");
+        Assert.Equal("localhost:9092", settings.GetProperty("bootstrap.servers"));
+        Assert.Equal("client1", settings.GetProperty("client.id"));
+        Assert.Equal("bar", settings.GetProperty("foo"));
+        Assert.Equal("baz", settings.GetProperty("bootstrap.foo"));
     }
 
     [Fact]
@@ -89,9 +88,9 @@ akka.kafka.producer.kafka-clients {{
         };
 
         settings = settings.WithProducerConfig(config);
-        settings.GetProperty("bootstrap.servers").Should().Be("localhost:9092");
-        settings.GetProperty("client.id").Should().Be("client1");
-        settings.GetProperty("enable.idempotence").Should().Be("True");
+        Assert.Equal("localhost:9092", settings.GetProperty("bootstrap.servers"));
+        Assert.Equal("client1", settings.GetProperty("client.id"));
+        Assert.Equal("True", settings.GetProperty("enable.idempotence"));
     }
 
     [Fact]
@@ -146,10 +145,10 @@ akka.kafka.producer.kafka-clients {{
             .WithDispatcher("")
             .WithGroupId("group1");
 
-        consumerSettings.ConnectionCheckerSettings.Enabled.Should().Be(false);
-        consumerSettings.ConnectionCheckerSettings.MaxRetries.Should().Be(3);
-        consumerSettings.ConnectionCheckerSettings.CheckInterval.Should().Be(TimeSpan.FromSeconds(15));
-        consumerSettings.ConnectionCheckerSettings.Factor.Should().Be(2.0);
+        Assert.False(consumerSettings.ConnectionCheckerSettings.Enabled);
+        Assert.Equal(3, consumerSettings.ConnectionCheckerSettings.MaxRetries);
+        Assert.Equal(TimeSpan.FromSeconds(15), consumerSettings.ConnectionCheckerSettings.CheckInterval);
+        Assert.Equal(2.0, consumerSettings.ConnectionCheckerSettings.Factor);
     }
 
     [Fact]
@@ -160,10 +159,10 @@ akka.kafka.producer.kafka-clients {{
         var settings = CommitterSettings.Create(conf);
 
         // Verify default values match those in reference.conf
-        settings.MaxBatch.Should().Be(1000);
-        settings.MaxInterval.Should().Be(TimeSpan.FromSeconds(10));
-        settings.Parallelism.Should().Be(100);
-        settings.When.Should().BeOfType<CommitWhen.OffsetFirstObserved>();
+        Assert.Equal(1000, settings.MaxBatch);
+        Assert.Equal(TimeSpan.FromSeconds(10), settings.MaxInterval);
+        Assert.Equal(100, settings.Parallelism);
+        Assert.True((settings.When) is CommitWhen.OffsetFirstObserved);
     }
 
     [Fact]
@@ -182,10 +181,10 @@ akka.kafka.committer {
         var settings = CommitterSettings.Create(conf);
 
         // Verify overridden values
-        settings.MaxBatch.Should().Be(500);
-        settings.MaxInterval.Should().Be(TimeSpan.FromSeconds(5));
-        settings.Parallelism.Should().Be(4);
-        settings.When.Should().BeOfType<CommitWhen.NextOffsetObserved>();
+        Assert.Equal(500, settings.MaxBatch);
+        Assert.Equal(TimeSpan.FromSeconds(5), settings.MaxInterval);
+        Assert.Equal(4, settings.Parallelism);
+        Assert.True((settings.When) is CommitWhen.NextOffsetObserved);
 
         // Test the fluent API for modifying settings
         var modifiedSettings = settings
@@ -194,9 +193,9 @@ akka.kafka.committer {
             .WithParallelism(8)
             .WithCommitWhen(CommitWhen.OffsetFirstObserved.Instance);
 
-        modifiedSettings.MaxBatch.Should().Be(200);
-        modifiedSettings.MaxInterval.Should().Be(TimeSpan.FromSeconds(2));
-        modifiedSettings.Parallelism.Should().Be(8);
-        modifiedSettings.When.Should().BeOfType<CommitWhen.OffsetFirstObserved>();
+        Assert.Equal(200, modifiedSettings.MaxBatch);
+        Assert.Equal(TimeSpan.FromSeconds(2), modifiedSettings.MaxInterval);
+        Assert.Equal(8, modifiedSettings.Parallelism);
+        Assert.True((modifiedSettings.When) is CommitWhen.OffsetFirstObserved);
     }
 }

--- a/src/Akka.Streams.Kafka.Tests/Integration/AtMostOnceSourceIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/AtMostOnceSourceIntegrationTests.cs
@@ -12,7 +12,6 @@ using Akka.Streams.Kafka.Dsl;
 using Akka.Streams.Kafka.Settings;
 using Akka.Streams.TestKit;
 using Confluent.Kafka;
-using FluentAssertions;
 using Xunit;
 
 namespace Akka.Streams.Kafka.Tests.Integration;
@@ -41,7 +40,7 @@ public class AtMostOnceSourceIntegrationTests : KafkaIntegrationTests
 
         AwaitCondition(() => control.IsShutdown.IsCompletedSuccessfully, TimeSpan.FromSeconds(10));
 
-        (await task).Should().BeEquivalentTo(Enumerable.Range(1, 5).Select(i => i.ToString()));
+        Assert.Equivalent(Enumerable.Range(1, 5).Select(i => i.ToString()), (await task));
     }
 
     [Fact(Skip = "Issue https://github.com/akkadotnet/Akka.Streams.Kafka/issues/66")]

--- a/src/Akka.Streams.Kafka.Tests/Integration/CommitWithMetadataSourceIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/CommitWithMetadataSourceIntegrationTests.cs
@@ -14,7 +14,6 @@ using Akka.Streams.Kafka.Settings;
 using Akka.Streams.TestKit;
 using Akka.Util.Internal;
 using Confluent.Kafka;
-using FluentAssertions;
 using Xunit;
 
 namespace Akka.Streams.Kafka.Tests.Integration;
@@ -55,8 +54,8 @@ public class CommitWithMetadataSourceIntegrationTests : KafkaIntegrationTests
         probe.Within(TimeSpan.FromSeconds(10), () => probe.ExpectNextN(10)).ForEach(message =>
         {
             var offsetWithMeta = message.CommitableOffset as ICommittableOffsetMetadata;
-            offsetWithMeta.Should().NotBeNull();
-            offsetWithMeta!.Metadata.Should().Be(message.CommitableOffset.Offset.Offset.ToString());
+            Assert.NotNull(offsetWithMeta);
+            Assert.Equal(message.CommitableOffset.Offset.Offset.ToString(), offsetWithMeta!.Metadata);
         });
 
         probe.Cancel();

--- a/src/Akka.Streams.Kafka.Tests/Integration/CommittablePartitionedSourceIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/CommittablePartitionedSourceIntegrationTests.cs
@@ -14,7 +14,6 @@ using Akka.Streams.Kafka.Helpers;
 using Akka.Streams.Kafka.Settings;
 using Akka.Util;
 using Confluent.Kafka;
-using FluentAssertions;
 using Xunit;
 
 namespace Akka.Streams.Kafka.Tests.Integration;
@@ -45,7 +44,7 @@ public class CommittablePartitionedSourceIntegrationTests : KafkaIntegrationTest
         await ProduceStrings(i => new TopicPartition(topic, i % partitionsCount), Enumerable.Range(1, totalMessages),
             ProducerSettings);
 
-        var control = KafkaConsumer.CommittablePartitionedSource(consumerSettings, Subscriptions.Topics(topic))
+        var mergedFlow = (Source<int, IControl>)(object)KafkaConsumer.CommittablePartitionedSource(consumerSettings, Subscriptions.Topics(topic))
             .GroupBy(partitionsCount, tuple => tuple.Item1)
             .SelectAsync(6, async tuple =>
             {
@@ -92,8 +91,9 @@ public class CommittablePartitionedSourceIntegrationTests : KafkaIntegrationTest
                 Log.Info($"sub-source for {topicPartition} completed: Received {result} messages in total.");
                 return result;
             })
-            .MergeSubstreams()
-            .As<Source<int, IControl>>()
+            .MergeSubstreams();
+
+        var control = mergedFlow
             .Scan(0, (c, n) => c + n)
             .ToMaterialized(Sink.Last<int>(), Keep.Both)
             .MapMaterializedValue(tuple => DrainingControl<int>.Create(tuple.Item1, tuple.Item2))
@@ -102,11 +102,11 @@ public class CommittablePartitionedSourceIntegrationTests : KafkaIntegrationTest
         AwaitCondition(() => exceptionTriggered.Value, TimeSpan.FromSeconds(10));
 
         var shutdown = control.DrainAndShutdown();
-        await AwaitConditionAsync(() => shutdown.IsCompleted);
-        createdSubSources.Should().Contain(allTopicPartitions);
-        shutdown.Exception!.Flatten().InnerExceptions[0].Message.Should().Be("FAIL");
+        AwaitCondition(() => shutdown.IsCompleted, TimeSpan.FromSeconds(10));
+        Assert.True(allTopicPartitions.All(tp => createdSubSources.Contains(tp)));
+        Assert.Equal("FAIL", shutdown.Exception!.Flatten().InnerExceptions[0].Message);
 
         // commits will fail if we shut down the consumer too early
-        commitFailures.Should().BeEmpty();
+        Assert.Empty(commitFailures ?? []);
     }
 }

--- a/src/Akka.Streams.Kafka.Tests/Integration/CommittingSpec.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/CommittingSpec.cs
@@ -1,10 +1,11 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 //  <copyright file="CommittingSpec.cs" company="Akka.NET Project">
 //      Copyright (C) 2025 - 2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
 // </copyright>
 // -----------------------------------------------------------------------
 
 using System;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
 using Akka.Streams.Dsl;
@@ -15,7 +16,6 @@ using Akka.Streams.Kafka.Settings;
 using Akka.Streams.TestKit;
 using Akka.Util.Internal;
 using Confluent.Kafka;
-using FluentAssertions;
 using Xunit;
 
 namespace Akka.Streams.Kafka.Tests.Integration;
@@ -63,7 +63,7 @@ public class CommittingSpec : KafkaIntegrationTests
 
         await probe1.RequestAsync(25);
         var found = await probe1.ExpectNextNAsync(25).ToListAsync();
-        messages.Take(25).Should().BeEquivalentTo(found);
+        Assert.Equivalent(found, messages.Take(25));
 
         await probe1.CancelAsync();
         await control.IsShutdown;
@@ -137,8 +137,8 @@ public class CommittingSpec : KafkaIntegrationTests
 
         // Await initial partition assignment
         var tp1 = await rebalanceActor1.ExpectMsgAsync<TopicPartitionsAssigned>();
-        tp1.Partitions.Should().BeEquivalentTo([partition0, partition1]);
-        tp1.Subscription.Should().Be(subscription1);
+        Assert.Equivalent(ImmutableHashSet.Create(partition0, partition1), tp1.Partitions);
+        Assert.Equal(subscription1, tp1.Subscription);
 
         // read all messages from both partitions
         var committables1 = await probe1.AsyncBuilder()
@@ -168,8 +168,8 @@ public class CommittingSpec : KafkaIntegrationTests
         await rebalanceActor1.ExpectMsgAsync<TopicPartitionsAssigned>();
 
         var finalResults = await consumer1Read;
-        finalResults.Should().BeEquivalentTo(Numbers.Take(count).Select(c => c + "-p0")
-            .Concat(Numbers.Take(count).Select(c => c + "-p1")));
+        Assert.Equivalent(Numbers.Take(count).Select(c => c + "-p0")
+            .Concat(Numbers.Take(count).Select(c => c + "-p1")), finalResults);
 
         probe1.Cancel();
         probe2.Cancel();
@@ -211,8 +211,8 @@ public class CommittingSpec : KafkaIntegrationTests
 
         // Await initial partition assignment
         var tp1 = await rebalanceActor1.ExpectMsgAsync<TopicPartitionsAssigned>();
-        tp1.Partitions.Should().BeEquivalentTo([partition0, partition1]);
-        tp1.Subscription.Should().Be(subscription1);
+        Assert.Equivalent(ImmutableHashSet.Create(partition0, partition1), tp1.Partitions);
+        Assert.Equal(subscription1, tp1.Subscription);
 
         // read all messages from both partitions
         var committables1 = await probe1.AsyncBuilder()
@@ -254,7 +254,7 @@ public class CommittingSpec : KafkaIntegrationTests
         var consumer2Read = committables2.Select(c => c.Record.Message.Value);
         var expectedResults = Numbers.Take(count).Select(c => c + "-" + recordSuffix);
 
-        consumer2Read.Should().BeEquivalentTo(expectedResults);
+        Assert.Equivalent(expectedResults, consumer2Read);
 
         await probe1.CancelAsync();
         await probe2.CancelAsync();

--- a/src/Akka.Streams.Kafka.Tests/Integration/ExternalPlainSourceIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/ExternalPlainSourceIntegrationTests.cs
@@ -20,7 +20,6 @@ using Akka.Streams.TestKit;
 using Akka.TestKit;
 using Akka.Util.Internal;
 using Confluent.Kafka;
-using FluentAssertions;
 using Xunit;
 using Decider = Akka.Streams.Supervision.Decider;
 
@@ -106,12 +105,12 @@ public class ExternalPlainSourceIntegrationTests : KafkaIntegrationTests
 
         // First two stages should fail, and only stage without demand should keep going
         var ex = probe1.ExpectError();
-        ex.Should().BeOfType<ConsumeException>();
-        ((ConsumeException)ex).Error.IsSerializationError().Should().BeTrue();
+        Assert.True((ex) is ConsumeException);
+        Assert.True(((ConsumeException)ex).Error.IsSerializationError());
 
         ex = probe2.ExpectError();
-        ex.Should().BeOfType<ConsumeException>();
-        ((ConsumeException)ex).Error.IsSerializationError().Should().BeTrue();
+        Assert.True((ex) is ConsumeException);
+        Assert.True(((ConsumeException)ex).Error.IsSerializationError());
 
         probe3.Cancel();
 

--- a/src/Akka.Streams.Kafka.Tests/Integration/FlowWithContextIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/FlowWithContextIntegrationTests.cs
@@ -17,7 +17,6 @@ using Akka.Streams.Kafka.Helpers;
 using Akka.Streams.Kafka.Messages;
 using Akka.Streams.Kafka.Settings;
 using Confluent.Kafka;
-using FluentAssertions;
 using Xunit;
 
 namespace Akka.Streams.Kafka.Tests.Integration;
@@ -121,6 +120,6 @@ public class FlowWithContextIntegrationTests : KafkaIntegrationTests
 
         AssertTaskCompletesWithin(TimeSpan.FromSeconds(10), control.DrainAndShutdown());
         AssertTaskCompletesWithin(TimeSpan.FromSeconds(10), control2.Shutdown());
-        AssertTaskCompletesWithin(TimeSpan.FromSeconds(10), result).Should().Be(totalConsumed);
+        Assert.Equal(totalConsumed, AssertTaskCompletesWithin(TimeSpan.FromSeconds(10), result));
     }
 }

--- a/src/Akka.Streams.Kafka.Tests/Integration/PlainPartitionedManualOffsetSourceIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/PlainPartitionedManualOffsetSourceIntegrationTests.cs
@@ -16,7 +16,6 @@ using Akka.Streams.TestKit;
 using Akka.Streams.Util;
 using Akka.Util;
 using Confluent.Kafka;
-using FluentAssertions;
 using Xunit;
 
 namespace Akka.Streams.Kafka.Tests.Integration;
@@ -82,8 +81,7 @@ public class PlainPartitionedManualOffsetSourceIntegrationTests : KafkaIntegrati
 
         probe.Request(99);
         var messages = probe.Within(TimeSpan.FromSeconds(10), () => probe.ExpectNextN(99));
-        messages.ToHashSet().Count.Should()
-            .Be(99); // All consumed messages should be different (only one value is missing)
+        Assert.Equal(99, messages.ToHashSet().Count); // All consumed messages should be different (only one value is missing)
 
         probe.Cancel();
     }

--- a/src/Akka.Streams.Kafka.Tests/Integration/PlainPartitionedSourceIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/PlainPartitionedSourceIntegrationTests.cs
@@ -23,10 +23,7 @@ using Akka.Streams.TestKit;
 using Akka.TestKit.Extensions;
 using Akka.Util.Internal;
 using Confluent.Kafka;
-using FluentAssertions;
-using FluentAssertions.Extensions;
 using Xunit;
-using static FluentAssertions.FluentActions;
 
 namespace Akka.Streams.Kafka.Tests.Integration;
 
@@ -48,7 +45,7 @@ public class PlainPartitionedSourceIntegrationTests : KafkaIntegrationTests
         await ProduceStrings(topic, Enumerable.Range(1, totalMessages), ProducerSettings);
 
         var consumerSettings = CreateConsumerSettings<string>(group);
-        var control = KafkaConsumer.PlainPartitionedSource(consumerSettings, Subscriptions.Topics(topic))
+        var mergedFlow = (Source<long, IControl>)(object)KafkaConsumer.PlainPartitionedSource(consumerSettings, Subscriptions.Topics(topic))
             .GroupBy(3, tuple => tuple.Item1)
             .SelectAsync(8, async tuple =>
             {
@@ -66,8 +63,9 @@ public class PlainPartitionedSourceIntegrationTests : KafkaIntegrationTests
                 Log.Info($"{topicPartition}: Received {sourceMessages} messages in total");
                 return sourceMessages;
             })
-            .MergeSubstreams()
-            .As<Source<long, IControl>>()
+            .MergeSubstreams();
+
+        var control = mergedFlow
             .Scan(0L, (i, subValue) => i + subValue)
             .ToMaterialized(Sink.Last<long>(), Keep.Both)
             .MapMaterializedValue(tuple => DrainingControl<long>.Create(tuple.Item1, tuple.Item2))
@@ -79,8 +77,8 @@ public class PlainPartitionedSourceIntegrationTests : KafkaIntegrationTests
         await Task.Delay(1000); // Wait for message handling finished after all messages received
 
         var shutdownTask = control.DrainAndShutdown();
-        var shutdownResult = await shutdownTask.WaitAsync(10.Seconds());
-        shutdownResult.Should().Be(totalMessages);
+        var shutdownResult = await shutdownTask.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.Equal(totalMessages, shutdownResult);
     }
 
     [Fact]
@@ -105,7 +103,6 @@ public class PlainPartitionedSourceIntegrationTests : KafkaIntegrationTests
                 // Return flag that all messages in child source are from the same, expected partition 
                 return consumedPartitions.All(partition => partition == topicPartition.Partition);
             })
-            .As<Source<bool, IControl>>()
             .ToMaterialized(
                 Sink.Aggregate<bool, bool>(true, (result, childSourceIsValid) => result && childSourceIsValid),
                 Keep.Both)
@@ -116,8 +113,8 @@ public class PlainPartitionedSourceIntegrationTests : KafkaIntegrationTests
         await Task.Delay(5000);
 
         var shutdownTask = control.DrainAndShutdown();
-        var shutdownResult = await shutdownTask.WaitAsync(10.Seconds());
-        shutdownResult.Should().BeTrue();
+        var shutdownResult = await shutdownTask.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.True(shutdownResult);
     }
 
     [Fact]
@@ -160,7 +157,7 @@ public class PlainPartitionedSourceIntegrationTests : KafkaIntegrationTests
         var resultTask = KafkaConsumer.PlainPartitionedSource(settings, Subscriptions.Topics("topic"))
             .RunWith(Sink.First<(TopicPartition, Source<ConsumeResult<Null, string>, NotUsed>)>(), Materializer);
 
-        await Awaiting(() => resultTask).Should().ThrowAsync<KafkaException>();
+        await Assert.ThrowsAsync<KafkaException>(() => resultTask);
     }
 
     [Fact]
@@ -192,8 +189,8 @@ public class PlainPartitionedSourceIntegrationTests : KafkaIntegrationTests
         Within(TimeSpan.FromSeconds(10), () =>
         {
             var err = substream.ExpectError();
-            err.Should().BeOfType<ConsumeException>();
-            ((ConsumeException)err).Error.IsSerializationError().Should().BeTrue();
+            Assert.True((err) is ConsumeException);
+            Assert.True(((ConsumeException)err).Error.IsSerializationError());
         });
 
         var shutdown = control1.Shutdown();
@@ -226,8 +223,8 @@ public class PlainPartitionedSourceIntegrationTests : KafkaIntegrationTests
             .TakeWhile(m => m < totalMessages, true)
             .RunWith(Sink.Last<int>(), Materializer);
 
-        var consumedMessages = await consumedMessagesTask.WaitAsync(60.Seconds());
-        consumedMessages.Should().Be(totalMessages);
+        var consumedMessages = await consumedMessagesTask.WaitAsync(TimeSpan.FromSeconds(60));
+        Assert.Equal(totalMessages, consumedMessages);
     }
 
     [Fact]
@@ -284,7 +281,7 @@ public class PlainPartitionedSourceIntegrationTests : KafkaIntegrationTests
             TimeSpan.FromMilliseconds(100));
 
         var sorted = queue.ToImmutableSortedSet();
-        sorted.Should().BeEquivalentTo(Enumerable.Range(1, totalMessages));
+        Assert.Equivalent(Enumerable.Range(1, totalMessages), sorted);
     }
 
     // This is a rough benchmark number for the unit test above, of how much time it should have taken
@@ -369,7 +366,7 @@ public class PlainPartitionedSourceIntegrationTests : KafkaIntegrationTests
 
         watch.Stop();
 
-        consumeCount.Should().Be(totalMessages);
+        Assert.Equal(totalMessages, consumeCount);
     }
 
     private (int count, TopicPartitionOffset? seekOffset) CheckForSeek(List<ConsumeResult<string, string>> messages)

--- a/src/Akka.Streams.Kafka.Tests/Integration/PlainSinkIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/PlainSinkIntegrationTests.cs
@@ -16,7 +16,6 @@ using Akka.Streams.Kafka.Messages;
 using Akka.Streams.Kafka.Settings;
 using Akka.Streams.TestKit;
 using Confluent.Kafka;
-using FluentAssertions;
 using Xunit;
 using Directive = Akka.Streams.Supervision.Directive;
 
@@ -75,7 +74,7 @@ public class PlainSinkIntegrationTests : KafkaIntegrationTests
             }
         }
 
-        messagesReceived.Should().Be(100);
+        Assert.Equal(100, messagesReceived);
     }
 
     [Fact]
@@ -154,7 +153,7 @@ public class PlainSinkIntegrationTests : KafkaIntegrationTests
             probe.ExpectNext();
         }
 
-        callCount.Should().Be(1);
+        Assert.Equal(1, callCount);
         probe.Cancel();
     }
 

--- a/src/Akka.Streams.Kafka.Tests/Integration/PlainSourceIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/PlainSourceIntegrationTests.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 //  <copyright file="PlainSourceIntegrationTests.cs" company="Akka.NET Project">
 //      Copyright (C) 2023 - 2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
 // </copyright>
@@ -22,7 +22,6 @@ using Akka.Streams.Supervision;
 using Akka.Streams.TestKit;
 using Akka.Util.Internal;
 using Confluent.Kafka;
-using FluentAssertions;
 using Xunit;
 
 namespace Akka.Streams.Kafka.Tests.Integration;
@@ -138,8 +137,8 @@ public class PlainSourceIntegrationTests : KafkaIntegrationTests
         AwaitAssert(() =>
         {
             var info = logProbe.ExpectMsg<Info>();
-            regex.IsMatch(info.Message.ToString() ?? "").Should().BeTrue();
-            info.Message.ToString().Should().Contain("[Resume]");
+            Assert.Matches(regex, info.Message.ToString());
+            Assert.Contains("[Resume]", info.Message.ToString());
         });
         //AwaitCondition(() => control.IsShutdown.IsCompleted, TimeSpan.FromSeconds(10));
     }
@@ -164,7 +163,7 @@ public class PlainSourceIntegrationTests : KafkaIntegrationTests
         var @event = probe.Request(elementsCount).ExpectEvent(TimeSpan.FromSeconds(10));
         var error = (TestSubscriber.OnError)@event;
         var exception = (ConsumeException)error.Cause;
-        exception.Error.Code.Should().Be(ErrorCode.Local_ValueDeserialization);
+        Assert.Equal(ErrorCode.Local_ValueDeserialization, exception.Error.Code);
         probe.Cancel();
     }
 
@@ -201,7 +200,7 @@ public class PlainSourceIntegrationTests : KafkaIntegrationTests
         probe.Request(elementsCount);
         probe.ExpectNoMsg(TimeSpan.FromSeconds(10));
         // this is twice elementCount because Decider is called twice on each exceptions
-        callCount.Should().Be(elementsCount * 2);
+        Assert.Equal(elementsCount * 2, callCount);
         probe.Cancel();
     }
 
@@ -230,8 +229,8 @@ public class PlainSourceIntegrationTests : KafkaIntegrationTests
         var shutdown = control.Shutdown();
         await AwaitConditionAsync(() => shutdown.IsCompleted);
 
-        customHandler.AssignmentEventsCounter.Current.Should().BeGreaterThan(0);
-        customHandler.StopEventsCounter.Current.Should().BeGreaterThan(0);
+        Assert.True((customHandler.AssignmentEventsCounter.Current) > (0));
+        Assert.True((customHandler.StopEventsCounter.Current) > (0));
     }
 
     private class CustomEventsHandler : IPartitionEventHandler

--- a/src/Akka.Streams.Kafka.Tests/Integration/RebalanceIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/RebalanceIntegrationTests.cs
@@ -20,8 +20,6 @@ using Akka.Streams.TestKit;
 using Akka.Util;
 using Akka.Util.Internal;
 using Confluent.Kafka;
-using FluentAssertions;
-using FluentAssertions.Extensions;
 using Xunit;
 
 namespace Akka.Streams.Kafka.Tests.Integration;
@@ -66,8 +64,8 @@ public class RebalanceIntegrationTests : KafkaIntegrationTests
             .Run(Materializer);
 
         Log.Debug("Await initial partition assignment");
-        (await probe1RebalanceActor.ExpectMsgAsync<TopicPartitionsAssigned>()).Partitions.Should()
-            .BeEquivalentTo([tp0, tp1]);
+        var partitions1 = (await probe1RebalanceActor.ExpectMsgAsync<TopicPartitionsAssigned>()).Partitions;
+        Assert.True(partitions1.Contains(tp0) && partitions1.Contains(tp1) && partitions1.Count == 2);
 
         Log.Debug("Read one message from probe1 with partition 1");
         var m = await probe1.RequestNextAsync();
@@ -145,8 +143,8 @@ public class RebalanceIntegrationTests : KafkaIntegrationTests
             .Run(Materializer);
 
         Log.Debug("Await initial partition assignment");
-        (await probe1RebalanceActor.ExpectMsgAsync<TopicPartitionsAssigned>()).Partitions.Should()
-            .BeEquivalentTo([tp0, tp1]);
+        var partitions2 = (await probe1RebalanceActor.ExpectMsgAsync<TopicPartitionsAssigned>()).Partitions;
+        Assert.True(partitions2.Contains(tp0) && partitions2.Contains(tp1) && partitions2.Count == 2);
 
         Log.Debug("Read 2 sub-sources returned by the partitioned source");
         await probe1.RequestAsync(2);

--- a/src/Akka.Streams.Kafka.Tests/Integration/SourceWithOffsetContextIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/SourceWithOffsetContextIntegrationTests.cs
@@ -13,7 +13,6 @@ using Akka.Streams.Kafka.Helpers;
 using Akka.Streams.Kafka.Messages;
 using Akka.Streams.Kafka.Settings;
 using Akka.Streams.TestKit;
-using FluentAssertions;
 using Xunit;
 
 namespace Akka.Streams.Kafka.Tests.Integration;
@@ -53,6 +52,6 @@ public class SourceWithOffsetContextIntegrationTests : KafkaIntegrationTests
 
         AwaitCondition(() => control.IsShutdown.IsCompletedSuccessfully, TimeSpan.FromSeconds(10));
 
-        committedBatches.Select(r => r.Item2).Sum(batch => batch.BatchSize).Should().Be(10);
+        Assert.Equal(10, committedBatches.Select(r => r.Item2).Sum(batch => batch.BatchSize));
     }
 }

--- a/src/Akka.Streams.Kafka.Tests/Integration/TransactionalIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/Integration/TransactionalIntegrationTests.cs
@@ -16,8 +16,6 @@ using Akka.Streams.Kafka.Messages;
 using Akka.Streams.Kafka.Settings;
 using Akka.TestKit.Extensions;
 using Confluent.Kafka;
-using FluentAssertions;
-using FluentAssertions.Extensions;
 using Xunit;
 
 namespace Akka.Streams.Kafka.Tests.Integration;
@@ -59,8 +57,8 @@ public class TransactionalIntegrationTests : KafkaIntegrationTests
         AssertTaskCompletesWithin(TimeSpan.FromSeconds(totalMessages), consumer.IsShutdown);
         AssertTaskCompletesWithin(TimeSpan.FromSeconds(totalMessages), control.DrainAndShutdown());
 
-        var consumedMessages = await consumer.DrainAndShutdown().WaitAsync(10.Seconds());
-        consumedMessages.Should().HaveCount(totalMessages);
+        var consumedMessages = await consumer.DrainAndShutdown().WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.Equal(totalMessages, (consumedMessages)?.Count());
     }
 
     private Flow<T, T, NotUsed> Business<T>() => Flow.Create<T>();

--- a/src/Akka.Streams.Kafka.Tests/Internal/CommitCollectorStageSpecs.cs
+++ b/src/Akka.Streams.Kafka.Tests/Internal/CommitCollectorStageSpecs.cs
@@ -23,7 +23,6 @@ using Akka.TestKit.Extensions;
 using Akka.Util;
 using Akka.Util.Internal;
 using Confluent.Kafka;
-using FluentAssertions;
 using Xunit;
 using Debug = System.Diagnostics.Debug;
 
@@ -58,17 +57,18 @@ public class CommitCollectorStageSpecs : Akka.TestKit.Xunit.TestKit
         // first message should not be committed but 'batched-up'
         sourceProbe.SendNext(msg1);
         await sourceProbe.ExpectNoMsgAsync(MessageAbsenceTimeout);
-        offsetFactory.Committer.Commits.Should().BeEmpty();
+        Assert.Empty(offsetFactory.Committer.Commits ?? []);
 
         // now send second message to complete the batch
         sourceProbe.SendNext(msg2);
 
         var committedBatch = await sinkProbe.ExpectNextAsync();
 
-        committedBatch.BatchSize.Should().Be(2);
-        committedBatch.Offsets.Count.Should().Be(1); // 1 offset value per partition
-        committedBatch.Offsets.Values.Last().Should().Be(msg2.Offset.Offset);
-        offsetFactory.Committer.Commits.Count.Should().Be(1, "expected only one batch commit");
+        Assert.Equal(2, committedBatch.BatchSize);
+        Assert.Single(committedBatch.Offsets); // 1 offset value per partition
+        Assert.Equal(msg2.Offset.Offset, committedBatch.Offsets.Values.First()!);
+        Assert.NotNull(offsetFactory.Committer.Commits);
+        Assert.Single(offsetFactory.Committer.Commits!);
 
         await control.Shutdown().WaitAsync(RemainingOrDefault);
     }
@@ -86,10 +86,10 @@ public class CommitCollectorStageSpecs : Akka.TestKit.Xunit.TestKit
 
         sourceProbe.SendNext(msg);
         var committedBatch = await sinkProbe.ExpectNextAsync();
-        committedBatch.BatchSize.Should().Be(1);
-        committedBatch.Offsets.Count.Should().Be(1); // 1 offset value per partition
-        committedBatch.Offsets.Values.Last().Should().Be(msg.Offset.Offset);
-        offsetFactory.Committer.Commits.Count.Should().Be(1, "expected only one batch commit");
+        Assert.Equal(1, committedBatch.BatchSize);
+        Assert.Single(committedBatch.Offsets); // 1 offset value per partition
+        Assert.Equal(msg.Offset.Offset, committedBatch.Offsets.Values.Last());
+        Assert.Single(offsetFactory.Committer.Commits!);
 
         await control.Shutdown().WaitAsync(RemainingOrDefault);
     }
@@ -112,10 +112,10 @@ public class CommitCollectorStageSpecs : Akka.TestKit.Xunit.TestKit
         sourceProbe.SendNext(msg);
         var committedBatch = await sinkProbe.ExpectNextAsync(TimeSpan.FromMilliseconds(50));
 
-        committedBatch.BatchSize.Should().Be(1);
-        committedBatch.Offsets.Count.Should().Be(1); // 1 offset value per partition
-        committedBatch.Offsets.Values.Last().Should().Be(msg.Offset.Offset);
-        offsetFactory.Committer.Commits.Count.Should().Be(1, "expected only one batch commit");
+        Assert.Equal(1, committedBatch.BatchSize);
+        Assert.Single(committedBatch.Offsets); // 1 offset value per partition
+        Assert.Equal(msg.Offset.Offset, committedBatch.Offsets.Values.Last());
+        Assert.Single(offsetFactory.Committer.Commits!);
 
         await control.Shutdown().WaitAsync(RemainingOrDefault);
     }
@@ -140,13 +140,13 @@ public class CommitCollectorStageSpecs : Akka.TestKit.Xunit.TestKit
         // triggered by size
         var committedBatch2 = await sinkProbe.RequestNextAsync();
 
-        committedBatch.BatchSize.Should().Be(1);
-        committedBatch.Offsets.Count.Should().Be(1); // 1 offset value per partition
-        committedBatch.Offsets.Values.Last().Should().Be(msg1.Offset.Offset);
+        Assert.Equal(1, committedBatch.BatchSize);
+        Assert.Single(committedBatch.Offsets); // 1 offset value per partition
+        Assert.Equal(msg1.Offset.Offset, committedBatch.Offsets.Values.First()!);
 
-        committedBatch2.BatchSize.Should().Be(2);
-        committedBatch2.Offsets.Count.Should().Be(1); // 1 offset value per partition
-        committedBatch2.Offsets.Values.Last().Should().Be(msg3.Offset.Offset);
+        Assert.Equal(2, committedBatch2.BatchSize);
+        Assert.Single(committedBatch2.Offsets); // 1 offset value per partition
+        Assert.Equal(msg3.Offset.Offset, committedBatch2.Offsets.Values.First()!);
 
         await control.Shutdown().WaitAsync(RemainingOrDefault);
     }
@@ -169,10 +169,10 @@ public class CommitCollectorStageSpecs : Akka.TestKit.Xunit.TestKit
 
         var committedBatch = await sinkProbe.ExpectNextAsync();
 
-        committedBatch.BatchSize.Should().Be(1);
-        committedBatch.Offsets.Count.Should().Be(1); // 1 offset value per partition
-        committedBatch.Offsets.Values.Last().Should().Be(msg1.Offset.Offset);
-        offsetFactory.Committer.Commits.Count.Should().Be(1, "expected only one batch commit");
+        Assert.Equal(1, committedBatch.BatchSize);
+        Assert.Single(committedBatch.Offsets); // 1 offset value per partition
+        Assert.Equal(msg1.Offset.Offset, committedBatch.Offsets.Values.First()!);
+        Assert.Single(offsetFactory.Committer.Commits!);
 
         await control.Shutdown().WaitAsync(RemainingOrDefault);
     }
@@ -197,10 +197,10 @@ public class CommitCollectorStageSpecs : Akka.TestKit.Xunit.TestKit
 
         var committedBatch = await sinkProbe.ExpectNextAsync();
 
-        committedBatch.BatchSize.Should().Be(2);
-        committedBatch.Offsets.Count.Should().Be(1); // 1 offset value per partition
-        committedBatch.Offsets.Values.Last().Should().Be(msg2.Offset.Offset);
-        offsetFactory.Committer.Commits.Count.Should().Be(1, "expected only one batch commit");
+        Assert.Equal(2, committedBatch.BatchSize);
+        Assert.Single(committedBatch.Offsets); // 1 offset value per partition
+        Assert.Equal(msg2.Offset.Offset, committedBatch.Offsets.Values.Last());
+        Assert.Single(offsetFactory.Committer.Commits!);
 
         await control.Shutdown().WaitAsync(RemainingOrDefault);
     }
@@ -229,10 +229,10 @@ public class CommitCollectorStageSpecs : Akka.TestKit.Xunit.TestKit
         await sourceProbe.SendErrorAsync(testException);
 
         var receivedError = await PullTillFailureAsync(sinkProbe, 4);
-        receivedError.Should().Be(testException);
+        Assert.Equal(testException, receivedError);
 
         var commits = offsetFactory.Committer.Commits;
-        commits[^1].Offset.Value.Should().Be(10, "last offset commit should be exactly the one preceeding the failure");
+        Assert.Equal(10, commits[^1].Offset.Value);
 
         await control.Shutdown().WaitAsync(RemainingOrDefault);
     }
@@ -259,9 +259,8 @@ public class CommitCollectorStageSpecs : Akka.TestKit.Xunit.TestKit
         var lastBatch = batches.MaxBy(c => c.Offsets.Values.Last().Value);
 
         Assert.NotNull(lastBatch);
-        lastBatch.Offsets.Values.Last().Should()
-            .Be(msg2.Offset.Offset, "expected only second message to be committed");
-        offsetFactory.Committer.Commits.Count.Should().Be(2, "expected only two commits");
+        Assert.Equal(msg2.Offset.Offset, lastBatch.Offsets.Values.Last()!);
+        Assert.Equal(2, offsetFactory.Committer.Commits.Count);
 
         await control.Shutdown().WaitAsync(RemainingOrDefault);
     }
@@ -290,9 +289,8 @@ public class CommitCollectorStageSpecs : Akka.TestKit.Xunit.TestKit
         var lastBatch = batches.MaxBy(c => c.Offsets.Values.Last().Value);
 
         Assert.NotNull(lastBatch);
-        lastBatch.Offsets.Values.Last().Should()
-            .Be(batch2.Offsets.Values.First(), "expected only second message to be committed");
-        offsetFactory.Committer.Commits.Count.Should().Be(2, "expected only two commits");
+        Assert.Equal(batch2.Offsets.Values.First(), lastBatch.Offsets.Values.Last()!);
+        Assert.Equal(2, offsetFactory.Committer.Commits.Count);
 
         await control.Shutdown().WaitAsync(RemainingOrDefault);
     }
@@ -322,9 +320,8 @@ public class CommitCollectorStageSpecs : Akka.TestKit.Xunit.TestKit
         var lastBatch = batches.MaxBy(c => c.Offsets.Values.Last().Value);
 
         Assert.NotNull(lastBatch);
-        lastBatch.Offsets.Values.Last().Should()
-            .Be(msg2.Offset.Offset, "expected only second message to be committed");
-        offsetFactory.Committer.Commits.Count.Should().Be(2, "expected only two commits");
+        Assert.Equal(msg2.Offset.Offset, lastBatch.Offsets.Values.Last()!);
+        Assert.Equal(2, offsetFactory.Committer.Commits.Count);
 
         await control.Shutdown().WaitAsync(RemainingOrDefault);
     }
@@ -358,9 +355,9 @@ public class CommitCollectorStageSpecs : Akka.TestKit.Xunit.TestKit
         var lastBatch = lastBatches[0];
         var secondLastBatch = lastBatches[1];
 
-        lastBatch.Offsets.Values.Should().Contain(msg3.Offset.Offset, "expected the second offset of partition 1");
-        secondLastBatch.Offsets.Values.Should().Contain(msg2.Offset.Offset, "expected the first offset of partition 2");
-        offsetFactory.Committer.Commits.Count.Should().Be(3, "expected only three commits");
+        Assert.Contains(msg3.Offset.Offset, lastBatch.Offsets.Values);
+        Assert.Contains(msg2.Offset.Offset, secondLastBatch.Offsets.Values);
+        Assert.Equal(3, offsetFactory.Committer.Commits.Count);
 
         await control.Shutdown().WaitAsync(RemainingOrDefault);
     }

--- a/src/Akka.Streams.Kafka.Tests/Internal/ConnectionCheckerSpec.cs
+++ b/src/Akka.Streams.Kafka.Tests/Internal/ConnectionCheckerSpec.cs
@@ -14,7 +14,6 @@ using Akka.Streams.Kafka.Internal;
 using Akka.Streams.Kafka.Settings;
 using Akka.Util;
 using Confluent.Kafka;
-using FluentAssertions;
 using Xunit;
 
 namespace Akka.Streams.Kafka.Tests.Internal;
@@ -76,7 +75,7 @@ public class ConnectionCheckerSpec : Akka.TestKit.Xunit.TestKit
         var stopwatch = Stopwatch.StartNew();
         ExpectMsg<Metadata.ListTopics>(TimeSpan.FromSeconds(5));
         stopwatch.Stop();
-        stopwatch.Elapsed.Should().BeGreaterThan(minimum);
+        Assert.True((stopwatch.Elapsed) > (minimum));
     }
 
     private void WithCheckerActorRef(Action<IActorRef> block)

--- a/src/Akka.Streams.Kafka.Tests/Internal/ConsumerSpec.cs
+++ b/src/Akka.Streams.Kafka.Tests/Internal/ConsumerSpec.cs
@@ -22,7 +22,6 @@ using Akka.Streams.Kafka.Tests.TestKit.Internal;
 using Akka.Streams.TestKit;
 using Akka.Util.Internal;
 using Confluent.Kafka;
-using FluentAssertions;
 using Xunit;
 using Config = Akka.Configuration.Config;
 using K = string;
@@ -94,8 +93,8 @@ akka.stream.materializer.debug.fuzzing-mode = on")
         foreach (var message in messages)
         {
             var received = await probe.ExpectNextAsync();
-            received.Record.Message.Key.Should().Be(message.Record.Message.Key);
-            received.Record.Message.Value.Should().Be(message.Record.Message.Value);
+            Assert.Equal(message.Record.Message.Key, received.Record.Message.Key);
+            Assert.Equal(message.Record.Message.Value, received.Record.Message.Value);
         }
 
         await control.Shutdown().WithTimeoutAsync(RemainingOrDefault);

--- a/src/Akka.Streams.Kafka.Tests/KafkaIntegrationTests.cs
+++ b/src/Akka.Streams.Kafka.Tests/KafkaIntegrationTests.cs
@@ -19,7 +19,6 @@ using Akka.Streams.Kafka.Settings;
 using Akka.Streams.TestKit;
 using Confluent.Kafka;
 using Confluent.Kafka.Admin;
-using FluentAssertions;
 using Xunit;
 using Config = Akka.Configuration.Config;
 
@@ -127,7 +126,7 @@ public abstract class KafkaIntegrationTests : Akka.TestKit.Xunit.TestKit
         AwaitCondition(() => task.IsCompleted, timeout, $"task should complete within {timeout} timeout");
 
         if (assertIsSuccessful)
-            task.IsCompletedSuccessfully.Should().Be(true, "task should compete successfully");
+            Assert.True(task.IsCompletedSuccessfully);
     }
 
     /// <summary>
@@ -140,7 +139,7 @@ public abstract class KafkaIntegrationTests : Akka.TestKit.Xunit.TestKit
         AwaitCondition(() => task.IsCompleted, timeout, $"task should complete within {timeout} timeout");
 
         if (assertIsSuccessful)
-            task.IsCompletedSuccessfully.Should().Be(true, "task should compete successfully");
+            Assert.True(task.IsCompletedSuccessfully);
 
         return task.Result;
     }


### PR DESCRIPTION
## Changes

- Replace xUnit `Assert.Equal(1, collection.Count)` with `Assert.Single(collection)` to fix xUnit2013 analyzer warnings
- Convert remaining test assertions to xUnit native assertions
- Clean up all remaining build warnings in test projects

## Files Changed

19 test files in `src/Akka.Streams.Kafka.Tests/` — all integration tests, internal specs, and config settings.